### PR TITLE
Generic EE export to Zarr.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Xee Examples
+
+Xee integrations & use cases.
+
+## Export Earth Engine ImageCollections to Zarr with [Xarray-Beam](https://github.com/google/xarray-beam)
+
+The following demonstrates how to export ~20 TiBs of NASA IMERG data to Zarr
+(in about ~25 LOC) with Xarray-Beam and GCP's Dataflow Runner. At the time of
+writing,  we were about to export this dataset in about ~3 hours (using Google's
+internal Beam runner).
+
+```shell
+python3 ee_to_zarr.py \
+  --input NASA/GPM_L3/IMERG_V06 \
+  --output $BUCKET/imerg_006.zarr \
+  --target_chunks "index=6" \
+  --runner DataflowRunner \
+  -- \
+  --project $PROJECT \
+  --region $REGION \
+  --disk_size_gb 50 \
+  --machine_type n2-highmem-2 \
+  --no_use_public_ips  \
+  --network $NETWORK \
+  --subnetwork regions/$REGION/subnetworks/$SUBNET \
+  --job_name imerg-to-zarr
+```

--- a/examples/ee_to_zarr.py
+++ b/examples/ee_to_zarr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-r"""Exports NASA/GPM_L3/IMERG_V06 to Zarr using Xarray-Beam."""
+r"""Exports EE ImageCollections to Zarr using Xarray-Beam."""
 from absl import app
 from absl import flags
 import apache_beam as beam
@@ -22,7 +22,17 @@ import xee
 
 import ee
 
-
+_INPUT = flags.DEFINE_string(
+    'input', '', help='The input Earth Engine ImageCollection.', required=True
+)
+_CRS = flags.DEFINE_string(
+    'crs',
+    'EPSG:4326',
+    help='Coordinate Reference System for output Zarr.',
+)
+_SCALE = flags.DEFINE_float(
+    'scale', 0.25, help='Scale factor for output Zarr.'
+)
 _TARGET_CHUNKS = flags.DEFINE_string(
     'target_chunks',
     '',
@@ -59,9 +69,9 @@ def main(argv: list[str]) -> None:
   ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com')
 
   ds = xr.open_dataset(
-      'NASA/GPM_L3/IMERG_V06',
-      crs='EPSG:4326',
-      scale=0.25,
+      _INPUT.value,
+      crs=_CRS.value,
+      scale=_SCALE.value,
       engine=xee.EarthEngineBackendEntrypoint,
   )
   template = xbeam.make_template(ds)


### PR DESCRIPTION
Generic EE export to Zarr.

Parameterized imerg_to_zarr. Now, the singular script can be used to export any EE ImageCollection to Zarr.

This PR also adds minimal documentation to describe how to accomplish this.
