### PR TITLE
Using the stable array endpoint from EE.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -430,7 +430,7 @@ class EarthEngineBackendArray(backends.BackendArray):
     """
     params = {
         'expression': image,
-        'fileFormat': 'NPY_DATA',
+        'fileFormat': 'NUMPY_NDARRAY',
         **kwargs,
     }
     raw = common.robust_getitem(


### PR DESCRIPTION
Using the stable array endpoint from EE.

Instead of `NPY_DATA`, the endpoint is now `NUMPY_NDARRAY`. This is the new stable API endpoint from EE. The data should be the same shape, otherwise.
