### PR TITLE
Simpler URL parsing scheme for remote EE assets.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -679,12 +679,11 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
   """Backend for Earth Engine."""
 
   def _parse(self, filename_or_obj: Union[str, os.PathLike[Any]]) -> str:
-    input_ = str(filename_or_obj).removeprefix('ee::')
-    parsed = parse.urlparse(input_)
+    parsed = parse.urlparse(str(filename_or_obj))
     if parsed.scheme and parsed.scheme != 'ee':
       raise ValueError(
           'uri must follow the format `ee://<image/collection/path>` or '
-          '`ee::<image/collection/path>`.'
+          '`ee:<image/collection/path>`.'
       )
     return f'{parsed.netloc}{parsed.path}'
 

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -239,7 +239,8 @@ class EEBackendEntrypointTest(absltest.TestCase):
         self.entry.guess_can_open('LANDSAT/SomeRandomCollection/C01/T1')
     )
     self.assertTrue(self.entry.guess_can_open('ee://LANDSAT/LC08/C01/T1'))
-    self.assertTrue(self.entry.guess_can_open('ee::LANDSAT/LC08/C01/T1'))
+    self.assertTrue(self.entry.guess_can_open('ee:LANDSAT/LC08/C01/T1'))
+    self.assertFalse(self.entry.guess_can_open('ee::LANDSAT/LC08/C01/T1'))
 
   def test_guess_can_open__image_collection(self):
     ic = ee.ImageCollection('LANDSAT/LC08/C01/T1').filterDate(
@@ -339,7 +340,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         dict(ds.dims), {'time': 3, 'lon': 15, 'lat': 8}
     )
     ds = self.entry.open_dataset(
-        'ee::LANDSAT/LC08/C01/T1',
+        'ee:LANDSAT/LC08/C01/T1',
         drop_variables=tuple(f'B{i}' for i in range(3, 12)),
         scale=25.0,  # in degrees
         n_images=3,


### PR DESCRIPTION
Simpler URL parsing scheme for remote EE assets.

@mahrsee1997 pointed out that there's an even simpler way to represent the parsing scheme for EE. Thanks, Rahul.
