### PR TITLE
Xee performance: Improving benchmarks.

### DIFF
--- a/xee/micro_benchmarks.py
+++ b/xee/micro_benchmarks.py
@@ -18,6 +18,7 @@ These are intended to always be run manually since they are more expensive test
 to run.
 """
 
+import cProfile
 import os
 import tempfile
 import timeit
@@ -32,6 +33,7 @@ import ee
 
 REPEAT = 10
 LOOPS = 1
+PROFILE = False
 
 
 def init_ee_for_tests():
@@ -74,6 +76,8 @@ def main(_: list[str]) -> None:
   init_ee_for_tests()
   print(f'[{REPEAT} time(s) with {LOOPS} loop(s) each.]')
   for fn in ['open_dataset()', 'open_and_chunk()', 'open_and_write()']:
+    if PROFILE:
+      cProfile.run(fn)
     timer = timeit.Timer(fn, globals=globals())
     res = timer.repeat(REPEAT, number=LOOPS)
     avg, std, best, worst = np.mean(res), np.std(res), np.min(res), np.max(res)


### PR DESCRIPTION
Xee performance: Improving benchmarks.

Makes improvements towards #29. Here, we group together all ee.getInfo() calls into one RPC call. In addition, this PR helped identify the underlying reason why Xee is slow (see #30). 

Status Quo:
```
open_dataset():avg=51.30,std=10.21,best=39.41,worst=68.27
open_and_chunk():avg=52.94,std=7.01,best=43.06,worst=63.03
open_and_write():avg=113.94,std=27.35,best=90.03,worst=173.90
```

After: 

```
open_dataset():avg=39.82,std=8.67,best=25.24,worst=55.54
open_and_chunk():avg=36.46,std=11.96,best=25.71,worst=59.83
open_and_write():avg=91.48,std=4.74,best=86.33,worst=104.08
```
