### PR TITLE
Add min Python version (3.8).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     },
     url='https://github.com/google/xee',
     packages=setuptools.find_packages(exclude=['examples']),
-    python_requires='>=3',
+    python_requires='>=3.8',
     entry_points={
         'xarray.backends': ['ee=xee:EarthEngineBackendEntrypoint'],
     }


### PR DESCRIPTION
Add min Python version (3.8).

Everything older than 3.8 is marked end-of-life: https://devguide.python.org/versions.
