### PR TITLE
Fix: bad default `scale_y` value.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -156,7 +156,7 @@ class EarthEngineStore(common.AbstractDataStore):
     default_scale = self.SCALE_UNITS.get(self.scale_units, 1)
     if scale is None:
       scale = default_scale
-    default_transform = affine.Affine.scale(scale)
+    default_transform = affine.Affine.scale(scale, -1 * scale)
 
     transform = affine.Affine(*proj.get('transform', default_transform)[:6])
     self.scale_x, self.scale_y = transform.a, transform.e


### PR DESCRIPTION
Fix: bad default `scale_y` value.

By default, `scale_y` was set to a positive value instead of a negative one. This lead to many datasets being all zeros, since it messed up the core projection calculation.

This PR adds a fix for this mistake as well as a data sanity integration test.
