### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ds = xarray.open_dataset(ic, engine='ee', crs='EPSG:4326', scale=0.25)
 Open an ImageCollection with a specific EE projection or geometry:
 
 ```python
-ic = ee.ImageCollection('ee://ECMWF/ERA5_LAND/HOURLY').filterDate('1992-10-05', '1993-03-31')
+ic = ee.ImageCollection('ECMWF/ERA5_LAND/HOURLY').filterDate('1992-10-05', '1993-03-31')
 leg1 = ee.Geometry.Rectangle(113.33, -43.63, 153.56, -10.66)
 ds = xarray.open_dataset(
     ic,


### PR DESCRIPTION
There is a typo with the example. This PR fixes it. 

![image](https://github.com/google/Xee/assets/5016453/a9a46712-c522-4409-900c-2d00dd9caa24)
