### PR TITLE
Better handling of setting EE nodata masked value to NaNs values.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -913,9 +913,8 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       primary_dim_property (optional): Override the `ee.Image` property for
         which to derive the values of the primary dimension. By default, this is
         'system:time_start'.
-      ee_mask_value (optional): Value to mask to EE nodata values. Matching is
-        done with `np.isclose`. By default, this is 'np.iinfo(np.int32).max'
-        (i.e. 2147483647).
+      ee_mask_value (optional): Value to mask to EE nodata values. By default,
+        this is 'np.iinfo(np.int32).max' i.e. 2147483647.
       request_byte_limit: the max allowed bytes to request at a time from Earth
         Engine. By default, it is 48MBs.
 

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -467,7 +467,7 @@ class EarthEngineStore(common.AbstractDataStore):
     data = arr.T
 
     # Sets EE nodata masked value to NaNs.
-    data = np.where(data == self.mask_value, np.nan, data)
+    data = np.where(np.isclose(data, self.mask_value), np.nan, data)
     return data
 
   @functools.lru_cache()

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -467,7 +467,7 @@ class EarthEngineStore(common.AbstractDataStore):
     data = arr.T
 
     # Sets EE nodata masked value to NaNs.
-    data = np.where(np.isclose(data, self.mask_value), np.nan, data)
+    data = np.where(np.isclose(data, self.mask_value, rtol= 1e-5), np.nan, data)
     return data
 
   @functools.lru_cache()

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -913,8 +913,9 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       primary_dim_property (optional): Override the `ee.Image` property for
         which to derive the values of the primary dimension. By default, this is
         'system:time_start'.
-      ee_mask_value (optional): Value to mask to EE nodata values. By default,
-        this is 'np.iinfo(np.int32).max' i.e. 2147483647.
+      ee_mask_value (optional): Value to mask to EE nodata values. Matching is
+        done with `np.isclose`. By default, this is 'np.iinfo(np.int32).max'
+        (i.e. 2147483647).
       request_byte_limit: the max allowed bytes to request at a time from Earth
         Engine. By default, it is 48MBs.
 

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -465,9 +465,9 @@ class EarthEngineStore(common.AbstractDataStore):
     # `raw` is a structured array of all the same dtype (i.e. number of images).
     arr = np.array(raw.tolist(), dtype=dtype)
     data = arr.T
-
+    current_mask_value = np.array(self.mask_value, dtype=data.dtype)
     # Sets EE nodata masked value to NaNs.
-    data = np.where(np.isclose(data, self.mask_value, rtol= 1e-5), np.nan, data)
+    data = np.where(data == current_mask_value, np.nan, data)
     return data
 
   @functools.lru_cache()


### PR DESCRIPTION
Fixed #86.

In the existing code, we're comparing data from Earth Engine, which arrives as floating-point numbers with 7-digit precision, to a masked value that's accurate to 9 digits. This discrepancy prevents a direct match. To address this, I introduced `np.isclose()`, which can match masked value with earth-engine data despite this precision difference.

Let's take an example:
```
import numpy as np
data = [(9999.,), (9999.01,), (9999.1,)]
Previous_Result = np.where( data == 9999, np.nan, data)
Current_Result = np.where( np.isclose(data, 9999), np.nan, data)
print(Previous_Result, Current_Result)
```
Output: 
```
Previous_Result : [[9999.  ] [9999.01] [9999.1 ]] 
Current_Result : [[nan] [nan] [9999.1]]
```
So `np.isclose` is match the value when their difference  is less than `0.1`.
Official documentation link: https://numpy.org/doc/stable/reference/generated/numpy.isclose.html#numpy-isclose.