### PR TITLE
CRS Attribute value updated.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -505,6 +505,7 @@ class EarthEngineStore(common.AbstractDataStore):
     x_dim_name, y_dim_name = self.dimension_names
     dimensions = [self.primary_dim_name, x_dim_name, y_dim_name]
     attrs = self._make_attrs_valid(self._band_attrs(name))
+    attrs['crs'] = self.crs
     encoding = {
         'source': attrs['id'],
         'scale_factor': arr.scale,


### PR DESCRIPTION
Fixed: #108 

The current code updated all the data in the `EPSG:4326`(Default) or user-defined `CRS` format but not updated the value of the CRS attribute and the attribute's value is same as in the actual data. So a dataarray within a dataset has different CRS.

A quick one-line fix is needed to update the value of the CRS attribute, ensuring that it accurately represents the modified data.
P.S.: this is not affected to the actual data.
