### PR TITLE
fix coordinate processing to handle variable return shapes from `image_to_array`

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -568,15 +568,16 @@ class EarthEngineStore(common.AbstractDataStore):
         (tile_size * i, min(tile_size * (i + 1), end_point))
         for i in range(tile_count)
     ]
-    tiles = [None] * tile_count
+    
+    coords = []
     with concurrent.futures.ThreadPoolExecutor() as pool:
       for i, arr in pool.map(
           self._get_tile_from_ee,
           list(zip(data, itertools.cycle([coordinate_type]))),
       ):
-        tiles[i] = arr.tolist() if coordinate_type == 'x' else arr.tolist()[0]
-    return np.concatenate(tiles)
-
+        coords.extend(arr.flatten())
+    return np.array(coords)
+ 
   def get_variables(self) -> utils.Frozen[str, xarray.Variable]:
     vars_ = [(name, self.open_store_variable(name)) for name in self._bands()]
 


### PR DESCRIPTION
In some cases, `lat` and `lon` would have different return shapes from `get_tile_from_ee`. This resulted in an error during `np.concatenate` like:

```
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 1 dimension(s) and the array at index 1 has 0 dimension(s)
```

This fixes the concatenation logic to just store a flattened array of coordinates. I think this should also resolve the same issue as #121, but I think it's slightly more robust since it supports all possible return shapes.

(I just went ahead and signed the CLA after putting this up for draft btw)