### PR TITLE
Fix: Use np.concatenate() instead of np.array() for merging 1D arrays with different sizes

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -595,7 +595,7 @@ class EarthEngineStore(common.AbstractDataStore):
           list(zip(data, itertools.cycle([coordinate_type]))),
       ):
         tiles[i] = arr.flatten()
-    return np.array(tiles)
+    return np.concatenate(tiles)
 
   def get_variables(self) -> utils.Frozen[str, xarray.Variable]:
     vars_ = [(name, self.open_store_variable(name)) for name in self._bands()]


### PR DESCRIPTION
Currently, the usage of `np.array()` inside the `_process_coordinate_data`  fails when attempting to merge 1D arrays with different sizes. This can be resolved by replacing np.array() with `np.concatenate()`, which effectively merges 1D arrays with varying shapes into a single 1D array.

Example code:
```
import numpy as np
day1 = np.random.randint(10, size=(5))
print(day1)

day2 = np.random.randint(10, size=(4))
print(day2)

allDays1 = np.array([day1, day2])  # not worked
allDays2 = np.concatenate([day1, day2]) # worked
print(allDays1)
```