### PR TITLE
fix: use absolut links for pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ i = ee.ImageCollection(ee.Image("LANDSAT/LC08/C02/T1_TOA/LC08_044034_20140318"))
 ds = xarray.open_dataset(i, engine='ee')
 ```
 
-See [examples](examples/) or [docs](docs/) for more uses and integrations.
+See [examples](https://github.com/google/Xee/tree/main/examples) or [docs](https://github.com/google/Xee/tree/main/docs) for more uses and integrations.
 
 ## License
 


### PR DESCRIPTION
The README is used to generate [pypi landing page](https://pypi.org/project/xee/) and in this context, your relative links are not pointing anywhere. 

With this very little change, you ensure that the readme page remains valid in other contexts than the GitHub display.