### PR TITLE
feat: support bbox in in geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ i = ee.ImageCollection(ee.Image("LANDSAT/LC08/C02/T1_TOA/LC08_044034_20140318"))
 ds = xarray.open_dataset(i, engine='ee')
 ```
 
+Open any Earth Engine ImageCollection to match an existing transform:
+
+```python
+raster = rioxarray.open_rasterio(...) # assume crs + transform is set
+ds = xr.open_dataset(
+    'ee://ECMWF/ERA5_LAND/HOURLY',
+    engine='ee',
+    geometry=tuple(raster.rio.bounds()), # must be in EPSG:4326
+    projection=ee.Projection(
+        crs=str(raster.rio.crs), transform=raster.rio.transform()[:6]
+    ),
+)
+```
+
 See [examples](examples/) or [docs](docs/) for more uses and integrations.
 
 ## License

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -25,7 +25,7 @@ import itertools
 import math
 import os
 import sys
-from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence, Tuple, Union
 from urllib import parse
 import warnings
 
@@ -139,7 +139,7 @@ class EarthEngineStore(common.AbstractDataStore):
       crs: Optional[str] = None,
       scale: Optional[float] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[Union[ee.Geometry, types.types.BBox]] = None,
+      geometry: Optional[Union[ee.Geometry, types.BBox]] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       mask_value: Optional[float] = None,
@@ -244,7 +244,7 @@ class EarthEngineStore(common.AbstractDataStore):
       x_min_0, y_min_0, x_max_0, y_max_0 = _ee_bounds_to_bounds(
           self.get_info['bounds']
       )
-    elif isinstance(geometry, Union[List, Tuple, np.ndarray]):
+    elif isinstance(geometry, Union[List, Tuple, np.ndarray, Sequence]):
       if len(geometry) != 4:
         raise ValueError(
             'geometry must be a 4-tuple of floats or a ee.Geometry, '

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -139,7 +139,9 @@ class EarthEngineStore(common.AbstractDataStore):
       crs: Optional[str] = None,
       scale: Optional[float] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[Union[ee.Geometry, Tuple[float, float, float, float]]] = None,
+      geometry: Union[
+          ee.Geometry, Tuple[float, float, float, float], None
+      ] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       mask_value: Optional[float] = None,
@@ -176,7 +178,9 @@ class EarthEngineStore(common.AbstractDataStore):
       crs: Optional[str] = None,
       scale: Union[float, int, None] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[Union[ee.Geometry, Tuple[float, float, float, float]]] = None,
+      geometry: Optional[
+          Union[ee.Geometry, Tuple[float, float, float, float]]
+      ] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       mask_value: Optional[float] = None,
@@ -253,8 +257,8 @@ class EarthEngineStore(common.AbstractDataStore):
       x_min_0, y_min_0, x_max_0, y_max_0 = geometry
     else:
       raise ValueError(
-          f'geometry must be a tuple or list of length 4, a ee.Geometry, or None '
-          f'but got {type(geometry)}'
+          'geometry must be a tuple or list of length 4, a ee.Geometry, or'
+          f' None but got {type(geometry)}'
       )
 
     x_min, y_min = self.transform(x_min_0, y_min_0)
@@ -960,7 +964,9 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       crs: Optional[str] = None,
       scale: Union[float, int, None] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[Union[ee.Geometry, Tuple[float, float, float, float]]] = None,
+      geometry: Optional[
+          Union[ee.Geometry, Tuple[float, float, float, float]]
+      ] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       ee_mask_value: Optional[float] = None,

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -139,7 +139,7 @@ class EarthEngineStore(common.AbstractDataStore):
       crs: Optional[str] = None,
       scale: Optional[float] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[Union[ee.Geometry, types.BBox]] = None,
+      geometry: Optional[Union[ee.Geometry, Tuple[float, float, float, float]]] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       mask_value: Optional[float] = None,
@@ -176,7 +176,7 @@ class EarthEngineStore(common.AbstractDataStore):
       crs: Optional[str] = None,
       scale: Union[float, int, None] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[Union[ee.Geometry, types.BBox]] = None,
+      geometry: Optional[Union[ee.Geometry, Tuple[float, float, float, float]]] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       mask_value: Optional[float] = None,
@@ -244,16 +244,16 @@ class EarthEngineStore(common.AbstractDataStore):
       x_min_0, y_min_0, x_max_0, y_max_0 = _ee_bounds_to_bounds(
           self.get_info['bounds']
       )
-    elif isinstance(geometry, Union[List, Tuple, np.ndarray, Sequence]):
+    elif isinstance(geometry, Union[List, Tuple]):
       if len(geometry) != 4:
         raise ValueError(
-            'geometry must be a 4-tuple of floats or a ee.Geometry, '
+            'geometry must be a tuple or list of length 4, or a ee.Geometry, '
             f'but got {geometry!r}'
         )
       x_min_0, y_min_0, x_max_0, y_max_0 = geometry
     else:
       raise ValueError(
-          'geometry must be a 4-tuple of floats or a ee.Geometry or None, '
+          f'geometry must be a tuple or list of length 4, a ee.Geometry, or None '
           f'but got {type(geometry)}'
       )
 
@@ -956,7 +956,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       crs: Optional[str] = None,
       scale: Union[float, int, None] = None,
       projection: Optional[ee.Projection] = None,
-      geometry: Optional[ee.Geometry] = None,
+      geometry: Optional[Union[ee.Geometry, Tuple[float, float, float, float]]] = None,
       primary_dim_name: Optional[str] = None,
       primary_dim_property: Optional[str] = None,
       ee_mask_value: Optional[float] = None,

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -594,7 +594,7 @@ class EarthEngineStore(common.AbstractDataStore):
     )
     target_image = ee.Image.pixelCoordinates(ee.Projection(self.crs_arg))
     return tile_index, self.image_to_array(
-        target_image, grid=bbox, dtype=np.float32, bandIds=[band_id]
+        target_image, grid=bbox, dtype=np.float64, bandIds=[band_id]
     )
 
   def _process_coordinate_data(

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -148,7 +148,8 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       use_coords_double_precision: bool = False,
-      match_xarray: xarray.DataArray | xarray.Dataset | None = None,
+      match_xarray: xarray.DataArray | xarray.Dataset | None = None
+
   ) -> 'EarthEngineStore':
     if mode != 'r':
       raise ValueError(
@@ -170,7 +171,7 @@ class EarthEngineStore(common.AbstractDataStore):
         ee_init_kwargs=ee_init_kwargs,
         ee_init_if_necessary=ee_init_if_necessary,
         use_coords_double_precision=use_coords_double_precision,
-        match_xarray=match_xarray,
+        match_xarray=match_xarray
     )
 
   def __init__(
@@ -189,7 +190,7 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       use_coords_double_precision: bool = False,
-      match_xarray: xr.DataArray | xr.Dataset | None = None,
+      match_xarray: xr.DataArray | xr.Dataset | None = None
   ):
     self.ee_init_kwargs = ee_init_kwargs
     self.ee_init_if_necessary = ee_init_if_necessary
@@ -215,7 +216,7 @@ class EarthEngineStore(common.AbstractDataStore):
     self.crs = CRS(self.crs_arg)
     if match_xarray is not None:
       if match_xarray.rio.crs is None:
-        raise ValueError('If matching to xarray, we require `.rio.crs` is set.')
+        raise ValueError("If matching to xarray, we require `.rio.crs` is set.")
       self.crs = CRS(match_xarray.rio.crs)
       if match_xarray[match_xarray.rio.x_dim].dtype == np.float64:
         self.use_coords_double_precision = True
@@ -1045,7 +1046,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       ee_init_kwargs: keywords to pass to Earth Engine Initialize when
         attempting to auto init for remote workers.
       use_coords_double_precision: Whether to use double precision for coordinates
-        and bounds from provided geometry. False by default, but True may be
+        and bounds from provided geometry. False by default, but True may be 
         helpful when hoping to match a transform of an existing dataset.
       match_xarray: An xarray.DataArray or xarray.Dataset to use as a template
         with rioxarray-based schema to extract the crs and transform to specify
@@ -1081,7 +1082,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
         ee_init_kwargs=ee_init_kwargs,
         ee_init_if_necessary=ee_init_if_necessary,
         use_coords_double_precision=use_coords_double_precision,
-        match_xarray=match_xarray,
+        match_xarray=match_xarray
     )
 
     store_entrypoint = backends_store.StoreBackendEntrypoint()

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -148,8 +148,7 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       use_coords_double_precision: bool = False,
-      match_xarray: xarray.DataArray | xarray.Dataset | None = None
-
+      match_xarray: xarray.DataArray | xarray.Dataset | None = None,
   ) -> 'EarthEngineStore':
     if mode != 'r':
       raise ValueError(
@@ -171,7 +170,7 @@ class EarthEngineStore(common.AbstractDataStore):
         ee_init_kwargs=ee_init_kwargs,
         ee_init_if_necessary=ee_init_if_necessary,
         use_coords_double_precision=use_coords_double_precision,
-        match_xarray=match_xarray
+        match_xarray=match_xarray,
     )
 
   def __init__(
@@ -190,7 +189,7 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       use_coords_double_precision: bool = False,
-      match_xarray: xr.DataArray | xr.Dataset | None = None
+      match_xarray: xr.DataArray | xr.Dataset | None = None,
   ):
     self.ee_init_kwargs = ee_init_kwargs
     self.ee_init_if_necessary = ee_init_if_necessary
@@ -216,7 +215,7 @@ class EarthEngineStore(common.AbstractDataStore):
     self.crs = CRS(self.crs_arg)
     if match_xarray is not None:
       if match_xarray.rio.crs is None:
-        raise ValueError("If matching to xarray, we require `.rio.crs` is set.")
+        raise ValueError('If matching to xarray, we require `.rio.crs` is set.')
       self.crs = CRS(match_xarray.rio.crs)
       if match_xarray[match_xarray.rio.x_dim].dtype == np.float64:
         self.use_coords_double_precision = True
@@ -1046,7 +1045,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       ee_init_kwargs: keywords to pass to Earth Engine Initialize when
         attempting to auto init for remote workers.
       use_coords_double_precision: Whether to use double precision for coordinates
-        and bounds from provided geometry. False by default, but True may be 
+        and bounds from provided geometry. False by default, but True may be
         helpful when hoping to match a transform of an existing dataset.
       match_xarray: An xarray.DataArray or xarray.Dataset to use as a template
         with rioxarray-based schema to extract the crs and transform to specify
@@ -1082,7 +1081,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
         ee_init_kwargs=ee_init_kwargs,
         ee_init_if_necessary=ee_init_if_necessary,
         use_coords_double_precision=use_coords_double_precision,
-        match_xarray=match_xarray
+        match_xarray=match_xarray,
     )
 
     store_entrypoint = backends_store.StoreBackendEntrypoint()

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -19,7 +19,7 @@ import pathlib
 import tempfile
 
 from absl.testing import absltest
-import google.auth
+from google.auth import identity_pool
 import numpy as np
 import xarray as xr
 from xarray.core import indexing
@@ -41,16 +41,19 @@ _SCOPES = [
 ]
 
 
-def _read_default_creds():
-  credentials, _ = google.auth.default(scopes=_SCOPES)
-  return credentials
+def _read_identity_pool_creds() -> identity_pool.Credentials:
+    credentials_path = os.environ[_CREDENTIALS_PATH_KEY]
+    with open(credentials_path) as file:
+        json_file = json.load(file)
+        credentials = identity_pool.Credentials.from_info(json_file)
+        return credentials.with_scopes(_SCOPES)
 
 
 def init_ee_for_tests():
-  ee.Initialize(
-      credentials=_read_default_creds(),
-      opt_url=ee.data.HIGH_VOLUME_API_BASE_URL,
-  )
+    ee.Initialize(
+        credentials=_read_identity_pool_creds(),
+        opt_url=ee.data.HIGH_VOLUME_API_BASE_URL,
+    )
 
 
 class EEBackendArrayTest(absltest.TestCase):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -393,7 +393,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         crs='EPSG:4326',
         use_coords_double_precision=True,
     ).rename({'lon': 'x', 'lat': 'y'})
-    # This is off slightly due to bounds determined by geometry e.g. .getInfo()
+    # This is off slightly due to bounds determined by geometry e.g. .getInfo() 
     # seems to cause a super slight shift in the bounds. Thhe coords change before
     # and after the call to .getInfo()!
     np.testing.assert_almost_equal(
@@ -401,7 +401,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         np.array(raster.rio.transform()),
         decimal=13,
     )
-
+  
   @absltest.skipIf(_SKIP_RASTERIO_TESTS, 'rioxarray module not loaded')
   def test_match_xarray(self):
     data = np.empty((162, 120), dtype=np.float32)

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -390,7 +390,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         crs='EPSG:4326',
         use_coords_double_precision=True,
     ).rename({'lon': 'x', 'lat': 'y'})
-    # This is off slightly due to bounds determined by geometry e.g. .getInfo() 
+    # This is off slightly due to bounds determined by geometry e.g. .getInfo()
     # seems to cause a super slight shift in the bounds. Thhe coords change before
     # and after the call to .getInfo()!
     np.testing.assert_almost_equal(
@@ -398,7 +398,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         np.array(raster.rio.transform()),
         decimal=13,
     )
-  
+
   @absltest.skipIf(_SKIP_RASTERIO_TESTS, 'rioxarray module not loaded')
   def test_match_xarray(self):
     data = np.empty((162, 120), dtype=np.float32)

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -378,8 +378,6 @@ class EEBackendEntrypointTest(absltest.TestCase):
         },
         dims=('y', 'x'),
     )
-
-    geo = ee.Geometry.Rectangle(*raster.rio.bounds())
     ic = (
         ee.ImageCollection('UCSB-CHG/CHIRPS/DAILY')
         .filterDate(ee.DateRange('2014-01-01', '2014-01-02'))
@@ -388,7 +386,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     xee_dataset = xr.open_dataset(
         ee.ImageCollection(ic),
         engine='ee',
-        geometry=geo,
+        geometry=tuple(raster.rio.bounds()),
         scale=raster.rio.resolution()[0],
         crs='EPSG:4326',
     ).rename({'lon': 'x', 'lat': 'y'})

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -42,18 +42,18 @@ _SCOPES = [
 
 
 def _read_identity_pool_creds() -> identity_pool.Credentials:
-    credentials_path = os.environ[_CREDENTIALS_PATH_KEY]
-    with open(credentials_path) as file:
-        json_file = json.load(file)
-        credentials = identity_pool.Credentials.from_info(json_file)
-        return credentials.with_scopes(_SCOPES)
+  credentials_path = os.environ[_CREDENTIALS_PATH_KEY]
+  with open(credentials_path) as file:
+    json_file = json.load(file)
+    credentials = identity_pool.Credentials.from_info(json_file)
+    return credentials.with_scopes(_SCOPES)
 
 
 def init_ee_for_tests():
-    ee.Initialize(
-        credentials=_read_identity_pool_creds(),
-        opt_url=ee.data.HIGH_VOLUME_API_BASE_URL,
-    )
+  ee.Initialize(
+      credentials=_read_identity_pool_creds(),
+      opt_url=ee.data.HIGH_VOLUME_API_BASE_URL,
+  )
 
 
 class EEBackendArrayTest(absltest.TestCase):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -359,7 +359,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     self.assertNotEqual(ds.dims, standard_ds.dims)
 
   @absltest.skipIf(_SKIP_RASTERIO_TESTS, 'rioxarray module not loaded')
-  def test_honors_transform_precisely(self):
+  def test_expected_double_precision_transform(self):
     data = np.empty((162, 120), dtype=np.float32)
     # An example of a double precision bbox
     bbox = (
@@ -391,49 +391,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         geometry=geo,
         scale=raster.rio.resolution()[0],
         crs='EPSG:4326',
-        use_coords_double_precision=True,
     ).rename({'lon': 'x', 'lat': 'y'})
-    # This is off slightly due to bounds determined by geometry e.g. .getInfo()
-    # seems to cause a super slight shift in the bounds. Thhe coords change before
-    # and after the call to .getInfo()!
-    np.testing.assert_almost_equal(
-        np.array(xee_dataset.rio.transform()),
-        np.array(raster.rio.transform()),
-        decimal=13,
-    )
-
-  @absltest.skipIf(_SKIP_RASTERIO_TESTS, 'rioxarray module not loaded')
-  def test_match_xarray(self):
-    data = np.empty((162, 120), dtype=np.float32)
-    # An example of a double precision bbox
-    bbox = (
-        -53.94158617595226,
-        -12.078281822698678,
-        -53.67209159071253,
-        -11.714464132625046,
-    )
-    x_res = (bbox[2] - bbox[0]) / data.shape[1]
-    y_res = (bbox[3] - bbox[1]) / data.shape[0]
-    raster = xr.DataArray(
-        data,
-        coords={
-            'y': np.linspace(bbox[3], bbox[1] + x_res, data.shape[0]),
-            'x': np.linspace(bbox[0], bbox[2] - y_res, data.shape[1]),
-        },
-        dims=('y', 'x'),
-    )
-    raster.rio.write_crs('EPSG:4326', inplace=True)
-    ic = (
-        ee.ImageCollection('UCSB-CHG/CHIRPS/DAILY')
-        .filterDate(ee.DateRange('2014-01-01', '2014-01-02'))
-        .select('precipitation')
-    )
-    xee_dataset = xr.open_dataset(
-        ee.ImageCollection(ic),
-        engine='ee',
-        scale=raster.rio.resolution()[0],
-        match_xarray=raster,
-    )
     np.testing.assert_equal(
         np.array(xee_dataset.rio.transform()),
         np.array(raster.rio.transform()),

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -393,7 +393,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         crs='EPSG:4326',
         use_coords_double_precision=True,
     ).rename({'lon': 'x', 'lat': 'y'})
-    # This is off slightly due to bounds determined by geometry e.g. .getInfo() 
+    # This is off slightly due to bounds determined by geometry e.g. .getInfo()
     # seems to cause a super slight shift in the bounds. Thhe coords change before
     # and after the call to .getInfo()!
     np.testing.assert_almost_equal(
@@ -401,7 +401,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         np.array(raster.rio.transform()),
         decimal=13,
     )
-  
+
   @absltest.skipIf(_SKIP_RASTERIO_TESTS, 'rioxarray module not loaded')
   def test_match_xarray(self):
     data = np.empty((162, 120), dtype=np.float32)


### PR DESCRIPTION
This pr adds support for matching an existing xarray dataset that adheres to rioxarray standards and to support float64 precision with coordinates. 

### Motivating Use Case of `match_xarray`:
- It will generally make it easier to merge datasets that come from somewhere else!
- e.g. I have a ton of LiDAR transects as their own tifs. Now I can open them in rioxarray and pass them to load data with the correct transform once instead of resampling again to match.

### Motivating Use Case of `use_coords_double_precision`:
- more precise transforms if matching closely is important to people
- allows a hacky and not exactly perfect approach to match to an existing xarray's transform if their dims are in float64
- when using double precision geometry objects to match the geometry of an existing dataset, `.getInfo()` seems to change the values so slightly! This motivated `np.testing.assert_all_close` instead of `np.testing.assert_equal`

🦩 
