### PR TITLE
Convert value outside of ee.Image boundary to NaN.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -463,7 +463,11 @@ class EarthEngineStore(common.AbstractDataStore):
     Returns:
       An numpy array containing the pixels computed based on the given image.
     """
-    image = ee.Image(self.mask_value).rename(image.bandNames().getInfo()[0]).blend(image)
+    image = (
+        ee.Image(self.mask_value)
+        .rename(image.bandNames().getInfo()[0])
+        .blend(image)
+    )
     params = {
         'expression': image,
         'fileFormat': 'NUMPY_NDARRAY',

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -465,7 +465,7 @@ class EarthEngineStore(common.AbstractDataStore):
     """
     image = (
         ee.Image(self.mask_value)
-        .rename(image.bandNames().getInfo()[0])
+        .rename([image.bandNames().get(0)])
         .blend(image)
     )
     params = {

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -279,9 +279,9 @@ class EarthEngineStore(common.AbstractDataStore):
       rpcs.append(('projection', self.projection))
 
     if isinstance(self.geometry, ee.Geometry):
-      rpcs.append(('bounds', self.geometry))
+      rpcs.append(('bounds', self.geometry.bounds()))
     else:
-      rpcs.append(('bounds', self.image_collection.first().geometry()))
+      rpcs.append(('bounds', self.image_collection.first().geometry().bounds()))
 
     # TODO(#29, #30): This RPC call takes the longest time to compute. This
     # requires a full scan of the images in the collection, which happens on the

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -463,7 +463,7 @@ class EarthEngineStore(common.AbstractDataStore):
     Returns:
       An numpy array containing the pixels computed based on the given image.
     """
-    image = image.unmask(self.mask_value)
+    image = ee.Image(self.mask_value).rename(image.bandNames().getInfo()[0]).blend(image)
     params = {
         'expression': image,
         'fileFormat': 'NUMPY_NDARRAY',

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -279,9 +279,9 @@ class EarthEngineStore(common.AbstractDataStore):
       rpcs.append(('projection', self.projection))
 
     if isinstance(self.geometry, ee.Geometry):
-      rpcs.append(('bounds', self.geometry.bounds()))
+      rpcs.append(('bounds', self.geometry))
     else:
-      rpcs.append(('bounds', self.image_collection.first().geometry().bounds()))
+      rpcs.append(('bounds', self.image_collection.first().geometry()))
 
     # TODO(#29, #30): This RPC call takes the longest time to compute. This
     # requires a full scan of the images in the collection, which happens on the

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -120,34 +120,26 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_basic_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
     first_two = arr[indexing.BasicIndexer((slice(0, 2), 0, 0))]
-    self.assertTrue(
-        np.allclose(np.isnan(first_two), np.isnan(np.full(2, np.nan)))
-    )
+    self.assertTrue(np.allclose(first_two, np.full(2, np.nan), equal_nan=True))
     first_three = arr[indexing.BasicIndexer((slice(0, 3), 0, 0))]
     self.assertTrue(
-        np.allclose(np.isnan(first_three), np.isnan(np.full(3, np.nan)))
+        np.allclose(first_three, np.full(3, np.nan), equal_nan=True)
     )
     last_two = arr[indexing.BasicIndexer((slice(-3, -1), 0, 0))]
-    self.assertTrue(
-        np.allclose(np.isnan(last_two), np.isnan(np.full(2, np.nan)))
-    )
+    self.assertTrue(np.allclose(last_two, np.full(2, np.nan), equal_nan=True))
     last_three = arr[indexing.BasicIndexer((slice(-4, -1), 0, 0))]
-    self.assertTrue(
-        np.allclose(np.isnan(last_three), np.isnan(np.full(3, np.nan)))
-    )
+    self.assertTrue(np.allclose(last_three, np.full(3, np.nan), equal_nan=True))
 
   def test_slice_indexing(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((0, slice(0, 10), slice(0, 10)))
     self.assertTrue(
-        np.allclose(
-            np.isnan(arr[first_10]), np.isnan(np.full((10, 10), np.nan))
-        )
+        np.allclose(arr[first_10], np.full((10, 10), np.nan), equal_nan=True)
     )
     last_5 = indexing.BasicIndexer((0, slice(-5, -1), slice(-5, -1)))
     expected_last_5 = np.full((4, 4), np.nan)
     self.assertTrue(
-        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])),
+        np.allclose(expected_last_5, arr[last_5], equal_nan=True),
         f'Actual:\n{arr[last_5]}',
     )
 
@@ -209,16 +201,14 @@ class EEBackendArrayTest(absltest.TestCase):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((slice(0, 2), slice(0, 10), slice(0, 10)))
     self.assertTrue(
-        np.allclose(
-            np.isnan(arr[first_10]), np.isnan(np.full((2, 10, 10), np.nan))
-        )
+        np.allclose(arr[first_10], np.full((2, 10, 10), np.nan), equal_nan=True)
     )
     last_5 = indexing.BasicIndexer(
         (slice(-3, -1), slice(-5, -1), slice(-5, -1))
     )
     expected_last_5 = np.full((2, 4, 4), np.nan)
     self.assertTrue(
-        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])),
+        np.allclose(expected_last_5, arr[last_5], equal_nan=True),
         f'Actual:\n{arr[last_5]}',
     )
 

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -99,8 +99,8 @@ class EEBackendArrayTest(absltest.TestCase):
 
   def test_basic_indexing(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
-    self.assertEqual(arr[indexing.BasicIndexer((0, 0, 0))], 0)
-    self.assertEqual(arr[indexing.BasicIndexer((-1, -1, -1))], np.array([0]))
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]), np.isnan(np.array(np.NaN)))
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]), np.isnan(np.array([np.NaN])))
 
   def test_basic_indexing__nonzero(self):
     arr = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
@@ -114,22 +114,22 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_basic_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
     first_two = arr[indexing.BasicIndexer((slice(0, 2), 0, 0))]
-    self.assertTrue(np.allclose(first_two, np.array([0, 0])))
+    self.assertTrue(np.allclose(np.isnan(first_two), np.isnan(np.full(2, np.nan))))
     first_three = arr[indexing.BasicIndexer((slice(0, 3), 0, 0))]
-    self.assertTrue(np.allclose(first_three, np.array([0, 0, 0])))
+    self.assertTrue(np.allclose(np.isnan(first_three), np.isnan(np.full(3, np.nan))))
     last_two = arr[indexing.BasicIndexer((slice(-3, -1), 0, 0))]
-    self.assertTrue(np.allclose(last_two, np.array([0, 0])))
+    self.assertTrue(np.allclose(np.isnan(last_two), np.isnan(np.full(2, np.nan))))
     last_three = arr[indexing.BasicIndexer((slice(-4, -1), 0, 0))]
-    self.assertTrue(np.allclose(last_three, np.array([0, 0, 0])))
+    self.assertTrue(np.allclose(np.isnan(last_three), np.isnan(np.full(3, np.nan))))
 
   def test_slice_indexing(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((0, slice(0, 10), slice(0, 10)))
-    self.assertTrue(np.allclose(arr[first_10], np.zeros((10, 10))))
+    self.assertTrue(np.allclose(np.isnan(arr[first_10]), np.isnan(np.full((10, 10), np.nan))))
     last_5 = indexing.BasicIndexer((0, slice(-5, -1), slice(-5, -1)))
-    expected_last_5 = np.zeros((4, 4))
+    expected_last_5 = np.full((4, 4), np.nan)
     self.assertTrue(
-        np.allclose(expected_last_5, arr[last_5]), f'Actual:\n{arr[last_5]}'
+        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])), f'Actual:\n{arr[last_5]}'
     )
 
   def test_slice_indexing__non_global(self):
@@ -189,13 +189,13 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_slice_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((slice(0, 2), slice(0, 10), slice(0, 10)))
-    self.assertTrue(np.allclose(arr[first_10], np.zeros((2, 10, 10))))
+    self.assertTrue(np.allclose(np.isnan(arr[first_10]), np.isnan(np.full((2, 10, 10), np.nan))))
     last_5 = indexing.BasicIndexer(
         (slice(-3, -1), slice(-5, -1), slice(-5, -1))
     )
-    expected_last_5 = np.zeros((2, 4, 4))
+    expected_last_5 = np.full((2, 4, 4), np.nan)
     self.assertTrue(
-        np.allclose(expected_last_5, arr[last_5]), f'Actual:\n{arr[last_5]}'
+        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])), f'Actual:\n{arr[last_5]}'
     )
 
   def test_slice_indexing__medium(self):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -99,14 +99,8 @@ class EEBackendArrayTest(absltest.TestCase):
 
   def test_basic_indexing(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
-    self.assertEqual(
-        np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]),
-        np.isnan(np.array(np.NaN)),
-    )
-    self.assertEqual(
-        np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]),
-        np.isnan(np.array([np.NaN])),
-    )
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]),True)
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]), True)
 
   def test_basic_indexing__nonzero(self):
     arr = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
@@ -352,7 +346,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         engine=xee.EarthEngineBackendEntrypoint,
     )
 
-    self.assertEqual(ds.dims, {'time': 4248, 'lon': 40, 'lat': 33})
+    self.assertEqual(ds.dims, {'time': 4248, 'lon': 40, 'lat': 35})
     self.assertNotEqual(ds.dims, standard_ds.dims)
 
   def test_honors_projection(self):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -114,28 +114,21 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_basic_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
     first_two = arr[indexing.BasicIndexer((slice(0, 2), 0, 0))]
-    self.assertTrue(np.allclose(first_two, np.full(2, np.nan), equal_nan=True))
+    np.testing.assert_equal(first_two, np.full(2, np.nan))
     first_three = arr[indexing.BasicIndexer((slice(0, 3), 0, 0))]
-    self.assertTrue(
-        np.allclose(first_three, np.full(3, np.nan), equal_nan=True)
-    )
+    np.testing.assert_equal(first_three, np.full(3, np.nan))
     last_two = arr[indexing.BasicIndexer((slice(-3, -1), 0, 0))]
-    self.assertTrue(np.allclose(last_two, np.full(2, np.nan), equal_nan=True))
+    np.testing.assert_equal(last_two, np.full(2, np.nan))
     last_three = arr[indexing.BasicIndexer((slice(-4, -1), 0, 0))]
-    self.assertTrue(np.allclose(last_three, np.full(3, np.nan), equal_nan=True))
+    np.testing.assert_equal(last_three, np.full(3, np.nan))
 
   def test_slice_indexing(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((0, slice(0, 10), slice(0, 10)))
-    self.assertTrue(
-        np.allclose(arr[first_10], np.full((10, 10), np.nan), equal_nan=True)
-    )
+    np.testing.assert_equal(arr[first_10], np.full((10, 10), np.nan))
     last_5 = indexing.BasicIndexer((0, slice(-5, -1), slice(-5, -1)))
     expected_last_5 = np.full((4, 4), np.nan)
-    self.assertTrue(
-        np.allclose(expected_last_5, arr[last_5], equal_nan=True),
-        f'Actual:\n{arr[last_5]}',
-    )
+    np.testing.assert_equal(expected_last_5, arr[last_5])
 
   def test_slice_indexing__non_global(self):
     arr = xee.EarthEngineBackendArray('spi2y', self.conus_store)
@@ -194,17 +187,12 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_slice_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((slice(0, 2), slice(0, 10), slice(0, 10)))
-    self.assertTrue(
-        np.allclose(arr[first_10], np.full((2, 10, 10), np.nan), equal_nan=True)
-    )
+    np.testing.assert_equal(arr[first_10], np.full((2, 10, 10), np.nan))
     last_5 = indexing.BasicIndexer(
         (slice(-3, -1), slice(-5, -1), slice(-5, -1))
     )
     expected_last_5 = np.full((2, 4, 4), np.nan)
-    self.assertTrue(
-        np.allclose(expected_last_5, arr[last_5], equal_nan=True),
-        f'Actual:\n{arr[last_5]}',
-    )
+    np.testing.assert_equal(expected_last_5, arr[last_5])
 
   def test_slice_indexing__medium(self):
     try:

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -352,7 +352,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         engine=xee.EarthEngineBackendEntrypoint,
     )
 
-    self.assertEqual(ds.dims, {'time': 4248, 'lon': 40, 'lat': 35})
+    self.assertEqual(ds.dims, {'time': 4248, 'lon': 40, 'lat': 33})
     self.assertNotEqual(ds.dims, standard_ds.dims)
 
   def test_honors_projection(self):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -99,8 +99,14 @@ class EEBackendArrayTest(absltest.TestCase):
 
   def test_basic_indexing(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
-    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]), np.isnan(np.array(np.NaN)))
-    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]), np.isnan(np.array([np.NaN])))
+    self.assertEqual(
+        np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]),
+        np.isnan(np.array(np.NaN)),
+    )
+    self.assertEqual(
+        np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]),
+        np.isnan(np.array([np.NaN])),
+    )
 
   def test_basic_indexing__nonzero(self):
     arr = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
@@ -114,22 +120,35 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_basic_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
     first_two = arr[indexing.BasicIndexer((slice(0, 2), 0, 0))]
-    self.assertTrue(np.allclose(np.isnan(first_two), np.isnan(np.full(2, np.nan))))
+    self.assertTrue(
+        np.allclose(np.isnan(first_two), np.isnan(np.full(2, np.nan)))
+    )
     first_three = arr[indexing.BasicIndexer((slice(0, 3), 0, 0))]
-    self.assertTrue(np.allclose(np.isnan(first_three), np.isnan(np.full(3, np.nan))))
+    self.assertTrue(
+        np.allclose(np.isnan(first_three), np.isnan(np.full(3, np.nan)))
+    )
     last_two = arr[indexing.BasicIndexer((slice(-3, -1), 0, 0))]
-    self.assertTrue(np.allclose(np.isnan(last_two), np.isnan(np.full(2, np.nan))))
+    self.assertTrue(
+        np.allclose(np.isnan(last_two), np.isnan(np.full(2, np.nan)))
+    )
     last_three = arr[indexing.BasicIndexer((slice(-4, -1), 0, 0))]
-    self.assertTrue(np.allclose(np.isnan(last_three), np.isnan(np.full(3, np.nan))))
+    self.assertTrue(
+        np.allclose(np.isnan(last_three), np.isnan(np.full(3, np.nan)))
+    )
 
   def test_slice_indexing(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((0, slice(0, 10), slice(0, 10)))
-    self.assertTrue(np.allclose(np.isnan(arr[first_10]), np.isnan(np.full((10, 10), np.nan))))
+    self.assertTrue(
+        np.allclose(
+            np.isnan(arr[first_10]), np.isnan(np.full((10, 10), np.nan))
+        )
+    )
     last_5 = indexing.BasicIndexer((0, slice(-5, -1), slice(-5, -1)))
     expected_last_5 = np.full((4, 4), np.nan)
     self.assertTrue(
-        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])), f'Actual:\n{arr[last_5]}'
+        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])),
+        f'Actual:\n{arr[last_5]}',
     )
 
   def test_slice_indexing__non_global(self):
@@ -189,13 +208,18 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_slice_indexing_multiple_images(self):
     arr = xee.EarthEngineBackendArray('B5', self.store)
     first_10 = indexing.BasicIndexer((slice(0, 2), slice(0, 10), slice(0, 10)))
-    self.assertTrue(np.allclose(np.isnan(arr[first_10]), np.isnan(np.full((2, 10, 10), np.nan))))
+    self.assertTrue(
+        np.allclose(
+            np.isnan(arr[first_10]), np.isnan(np.full((2, 10, 10), np.nan))
+        )
+    )
     last_5 = indexing.BasicIndexer(
         (slice(-3, -1), slice(-5, -1), slice(-5, -1))
     )
     expected_last_5 = np.full((2, 4, 4), np.nan)
     self.assertTrue(
-        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])), f'Actual:\n{arr[last_5]}'
+        np.allclose(np.isnan(expected_last_5), np.isnan(arr[last_5])),
+        f'Actual:\n{arr[last_5]}',
     )
 
   def test_slice_indexing__medium(self):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -99,7 +99,7 @@ class EEBackendArrayTest(absltest.TestCase):
 
   def test_basic_indexing(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
-    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]),True)
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]), True)
     self.assertEqual(np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]), True)
 
   def test_basic_indexing__nonzero(self):


### PR DESCRIPTION
Fixed: #131.

As mentioned in the #131, the current code returns `0 values` for the external boundary of the clipped region. However, this is incorrect, and therefore, these values should be converted to  the `NaN values`.

Approach: Create a global image with a constant value, and then blend this image with the actual image, ensuring that the original image data is preserved in the final image.