### PR TITLE
Geometry bounds are updated with the projection.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -279,11 +279,13 @@ class EarthEngineStore(common.AbstractDataStore):
       rpcs.append(('projection', self.projection))
 
     if isinstance(self.geometry, ee.Geometry):
-      rpcs.append(('bounds', self.geometry.bounds(proj=self.projection)))
+      rpcs.append(('bounds', self.geometry.bounds(1, proj=self.projection)))
     else:
       rpcs.append((
           'bounds',
-          self.image_collection.first().geometry().bounds(proj=self.projection),
+          self.image_collection.first()
+          .geometry()
+          .bounds(1, proj=self.projection),
       ))
 
     # TODO(#29, #30): This RPC call takes the longest time to compute. This

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -279,9 +279,9 @@ class EarthEngineStore(common.AbstractDataStore):
       rpcs.append(('projection', self.projection))
 
     if isinstance(self.geometry, ee.Geometry):
-      rpcs.append(('bounds', self.geometry.bounds()))
+      rpcs.append(('bounds', self.geometry.bounds(proj = self.projection)))
     else:
-      rpcs.append(('bounds', self.image_collection.first().geometry().bounds()))
+      rpcs.append(('bounds', self.image_collection.first().geometry().bounds(proj = self.projection)))
 
     # TODO(#29, #30): This RPC call takes the longest time to compute. This
     # requires a full scan of the images in the collection, which happens on the

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -279,9 +279,12 @@ class EarthEngineStore(common.AbstractDataStore):
       rpcs.append(('projection', self.projection))
 
     if isinstance(self.geometry, ee.Geometry):
-      rpcs.append(('bounds', self.geometry.bounds(proj = self.projection)))
+      rpcs.append(('bounds', self.geometry.bounds(proj=self.projection)))
     else:
-      rpcs.append(('bounds', self.image_collection.first().geometry().bounds(proj = self.projection)))
+      rpcs.append((
+          'bounds',
+          self.image_collection.first().geometry().bounds(proj=self.projection),
+      ))
 
     # TODO(#29, #30): This RPC call takes the longest time to compute. This
     # requires a full scan of the images in the collection, which happens on the

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -280,12 +280,14 @@ class EarthEngineStore(common.AbstractDataStore):
     if isinstance(self.geometry, ee.Geometry):
       rpcs.append(('bounds', self.geometry.bounds(1, proj=self.projection)))
     else:
-      rpcs.append((
-          'bounds',
-          self.image_collection.first()
-          .geometry()
-          .bounds(1, proj=self.projection),
-      ))
+      rpcs.append(
+          (
+              'bounds',
+              self.image_collection.first()
+              .geometry()
+              .bounds(1, proj=self.projection),
+          )
+      )
 
     # TODO(#29, #30): This RPC call takes the longest time to compute. This
     # requires a full scan of the images in the collection, which happens on the
@@ -298,14 +300,16 @@ class EarthEngineStore(common.AbstractDataStore):
     # client-side. Ideally, this would live behind a xarray-backend-specific
     # feature flag, since it's not guaranteed that data is this consistent.
     columns = ['system:id', self.primary_dim_property]
-    rpcs.append((
-        'properties',
+    rpcs.append(
         (
-            self.image_collection.reduceColumns(
-                ee.Reducer.toList().repeat(len(columns)), columns
-            ).get('list')
-        ),
-    ))
+            'properties',
+            (
+                self.image_collection.reduceColumns(
+                    ee.Reducer.toList().repeat(len(columns)), columns
+                ).get('list')
+            ),
+        )
+    )
 
     info = ee.List([rpc for _, rpc in rpcs]).getInfo()
 

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -259,6 +259,32 @@ class EEBackendArrayTest(absltest.TestCase):
 
     self.assertEqual(getter.count, 3)
 
+  def test_geometry_bounds_with_and_without_projection(self):
+    image = (
+        ee.ImageCollection('LANDSAT/LC08/C01/T1')
+        .filterDate('2017-01-01', '2017-01-03')
+        .first()
+    )
+    point = ee.Geometry.Point(-40.2414893624401, 105.48790177216375)
+    distance = 311.5
+    scale = 5000
+    projection = ee.Projection('EPSG:4326', [1, 0, 0, 0, -1, 0]).atScale(scale)
+    image = image.reproject(projection)
+
+    geometry = point.buffer(distance, proj=projection).bounds(proj=projection)
+
+    data_store = xee.EarthEngineStore(
+        ee.ImageCollection(image),
+        projection=image.projection(),
+        geometry=geometry,
+    )
+    data_store_bounds = data_store.get_info['bounds']
+
+    self.assertNotEqual(geometry.bounds().getInfo(), data_store_bounds)
+    self.assertEqual(
+        geometry.bounds(1, proj=projection).getInfo(), data_store_bounds
+    )
+
 
 class EEBackendEntrypointTest(absltest.TestCase):
 


### PR DESCRIPTION
In the current implementation, we are utilizing [`geometry.bounds().getInfo()`](https://github.com/google/Xee/blob/main/xee/ext.py#L282-L284) to retrieve the bound points. However, this approach yields inconsistent results when the `latitude value` of a point exceeds `104`, resulting in the return of a `constant latitude value`. So I am adding the projection into the bound points to fix this issue.

Example:
```
ee_image = ee.Image("projects/anthromet-prod/assets/1km_uk_nimrod_composite_rainfall_radar/202202120220_nimrod_ng_radar_rainrate_composite_1km_UK")

scale = 5000
projection = ee.Projection("EPSG:4326", [1, 0, 0, 0, -1, 0]).atScale(scale)
ee_image = ee_image.reproject(projection)

point = ee.Geometry.Point(-110.2414893624401 ,104)
distance = 311.5
geometry = point.buffer(distance, proj=projection).bounds(proj=projection)

ic = ee.ImageCollection([ee_image])
ds = xarray.open_dataset(
    ic, projection=ee_image.projection(), geometry=geometry,
    ee_mask_value=-99999, engine = 'ee'
)
ds
```
The above ds returns only a `single latitude point` when utilizing the current code. However, upon updating the bounds with `bounds(proj = projection)`, the ds accurately returns 623 latitude points.

Thank you @bbabenko for suggesting the above apporoach.