### PR TITLE
Support added for the int datatype earth engine image.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -719,7 +719,7 @@ class EarthEngineBackendArray(backends.BackendArray):
     # It looks like different bands have different dimensions & transforms!
     # Can we get this into consistent dimensions?
     self._info = ee_store._band_attrs(variable_name)
-    self.dtype = _parse_dtype(self._info['data_type'])
+    self.dtype = np.dtype(np.float32)
 
     x_min, y_min, x_max, y_max = self.bounds
 

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -471,6 +471,7 @@ class EarthEngineStore(common.AbstractDataStore):
     Returns:
       An numpy array containing the pixels computed based on the given image.
     """
+    image = image.toFloat()
     image = (
         ee.Image(self.mask_value)
         .rename([image.bandNames().get(0)])

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -726,8 +726,7 @@ class EarthEngineBackendArray(backends.BackendArray):
     # It looks like different bands have different dimensions & transforms!
     # Can we get this into consistent dimensions?
     self._info = ee_store._band_attrs(variable_name)
-    self.dtype = _parse_dtype(self._info['data_type'])
-
+    self.dtype = np.dtype(np.float32)
     x_min, y_min, x_max, y_max = self.bounds
 
     # Make sure the size is at least 1x1.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -469,17 +469,8 @@ class EarthEngineStore(common.AbstractDataStore):
     Returns:
       A numpy array of float data value containing the pixels computed based on the given image.
     """
-    image = image.toFloat()
-    image = (
-        ee.Image(self.mask_value)
-        .rename([image.bandNames().get(0)])
-        .blend(image)
-    )
-    params = {
-        'expression': image,
-        'fileFormat': 'NUMPY_NDARRAY',
-        **kwargs,
-    }
+    image = image.unmask(self.mask_value, False)
+    params = {'expression': image, 'fileFormat': 'NUMPY_NDARRAY', **kwargs}
     raw = common.robust_getitem(
         pixels_getter, params, catch=ee.ee_exception.EEException
     )

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -69,6 +69,7 @@ class EEBackendArrayTest(absltest.TestCase):
             '2017-01-01', '2017-01-03'
         ),
         n_images=64,
+        mask_value=-99999,
     )
     self.lnglat_store = xee.EarthEngineStore(
         ee.ImageCollection.fromImages([ee.Image.pixelLonLat()]),

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -75,7 +75,7 @@ class EEBackendArrayTest(absltest.TestCase):
             '2017-01-01', '2017-01-03'
         ),
         n_images=64,
-        mask_value=-9999
+        mask_value=-9999,
     )
     self.lnglat_store = xee.EarthEngineStore(
         ee.ImageCollection.fromImages([ee.Image.pixelLonLat()]),

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -104,7 +104,7 @@ class EEBackendArrayTest(absltest.TestCase):
     self.assertIsNotNone(arr)
 
     self.assertEqual((64, 360, 180), arr.shape)
-    self.assertEqual(np.int32, arr.dtype)
+    self.assertEqual(np.float32, arr.dtype)
     self.assertEqual('B4', arr.variable_name)
 
   def test_basic_indexing(self):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -70,6 +70,13 @@ class EEBackendArrayTest(absltest.TestCase):
         ),
         n_images=64,
     )
+    self.store_with_neg_mask_value = xee.EarthEngineStore(
+        ee.ImageCollection('LANDSAT/LC08/C01/T1').filterDate(
+            '2017-01-01', '2017-01-03'
+        ),
+        n_images=64,
+        mask_value=-9999
+    )
     self.lnglat_store = xee.EarthEngineStore(
         ee.ImageCollection.fromImages([ee.Image.pixelLonLat()]),
         chunks={'index': 256, 'width': 512, 'height': 512},
@@ -97,11 +104,16 @@ class EEBackendArrayTest(absltest.TestCase):
     self.assertIsNotNone(arr)
 
     self.assertEqual((64, 360, 180), arr.shape)
-    self.assertEqual(np.int32, arr.dtype)
+    self.assertEqual(np.float32, arr.dtype)
     self.assertEqual('B4', arr.variable_name)
 
   def test_basic_indexing(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]), True)
+    self.assertEqual(np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]), True)
+
+  def test_basic_indexing_on_int_ee_image(self):
+    arr = xee.EarthEngineBackendArray('B4', self.store_with_neg_mask_value)
     self.assertEqual(np.isnan(arr[indexing.BasicIndexer((0, 0, 0))]), True)
     self.assertEqual(np.isnan(arr[indexing.BasicIndexer((-1, -1, -1))]), True)
 

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -69,7 +69,6 @@ class EEBackendArrayTest(absltest.TestCase):
             '2017-01-01', '2017-01-03'
         ),
         n_images=64,
-        mask_value=-99999,
     )
     self.lnglat_store = xee.EarthEngineStore(
         ee.ImageCollection.fromImages([ee.Image.pixelLonLat()]),
@@ -244,14 +243,12 @@ class EEBackendArrayTest(absltest.TestCase):
           raise ee.ee_exception.EEException('Too many requests!')
         return ee.data.computePixels(params)
 
-    arr = xee.EarthEngineBackendArray('B5', self.store)
     grid = self.store.project((0, 10, 0, 10))
     getter = ErroneousPixelsGetter()
     self.store.image_to_array(
         self.store.image_collection.first(),
         pixels_getter=getter,
         grid=grid,
-        dtype=arr.dtype,
     )
 
     self.assertEqual(getter.count, 3)

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -255,12 +255,14 @@ class EEBackendArrayTest(absltest.TestCase):
           raise ee.ee_exception.EEException('Too many requests!')
         return ee.data.computePixels(params)
 
+    arr = xee.EarthEngineBackendArray('B5', self.store)
     grid = self.store.project((0, 10, 0, 10))
     getter = ErroneousPixelsGetter()
     self.store.image_to_array(
         self.store.image_collection.first(),
         pixels_getter=getter,
         grid=grid,
+        dtype=arr.dtype,
     )
 
     self.assertEqual(getter.count, 3)

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -148,11 +148,11 @@ class EEBackendArrayTest(absltest.TestCase):
   def test_slice_indexing__non_global(self):
     arr = xee.EarthEngineBackendArray('spi2y', self.conus_store)
     first_10 = indexing.BasicIndexer((0, slice(0, 10), slice(0, 10)))
-    self.assertTrue(np.allclose(arr[first_10], np.zeros((10, 10))))
+    np.testing.assert_equal(arr[first_10], np.full((10, 10), np.nan))
     last_5 = indexing.BasicIndexer((0, slice(-5, -1), slice(-5, -1)))
-    expected_last_5 = np.zeros((4, 4))
-    self.assertTrue(
-        np.allclose(expected_last_5, arr[last_5]), f'Actual:\n{arr[last_5]}'
+    expected_last_5 = np.full((4, 4), np.nan)
+    np.testing.assert_equal(
+        expected_last_5, arr[last_5], f'Actual:\n{arr[last_5]}'
     )
 
   # TODO(alxr): Add more tests here to check for off-by-one errors...

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -104,7 +104,7 @@ class EEBackendArrayTest(absltest.TestCase):
     self.assertIsNotNone(arr)
 
     self.assertEqual((64, 360, 180), arr.shape)
-    self.assertEqual(np.float32, arr.dtype)
+    self.assertEqual(np.int32, arr.dtype)
     self.assertEqual('B4', arr.variable_name)
 
   def test_basic_indexing(self):


### PR DESCRIPTION
The existing code of the Xee is incapable of processing the Earth Engine images which have data of  integer datatype. As illustrated in the example below, instead of yielding a "NaN" value, it produces a value that is **one less than** the `ee_mask_value`. For instance, if the `ee_mask_value` is set to -99990, the code will return -99989.

Ex.:
**Before** :
```
image = ee.Image('USGS/GMTED2010').select('be75')
proj_4326 = ee.Projection('EPSG:4326', [1, 0, 0, 0, -1, 0]).atScale(10000)
image = image.reproject(proj_4326)
geom = ee.Geometry.Rectangle( [[-179.99, -80], [179.99, 80]], None, geodesic=False,)
```
```
ic = ee.ImageCollection([image])
ds = xarray.open_dataset(ic, projection=image.projection(), geometry=geom,
     ee_mask_value=-99999, engine='ee'
)
ds.be75.values
```
Result:
```
array([[[     0.,      0.,      0., ..., -99998., -99998., -99998.],
        [     0.,      0.,      0., ..., -99998., -99998., -99998.],
        [     0.,      0.,      0., ..., -99998., -99998., -99998.],
        ...,
        [     0.,      0.,      0., ..., -99998., -99998., -99998.],
        [     0.,      0.,      0., ..., -99998., -99998., -99998.],
        [     0.,      0.,      0., ..., -99998., -99998., -99998.]]])
```
**After** updating the code :
```
ic = ee.ImageCollection([image])
ds = ee_local_class.open_dataset(ic, projection=image.projection(), geometry=geom,
     ee_mask_value=-99999,
)
ds.be75.values
```
Result:
```
array([[[ 0.,  0.,  0., ..., nan, nan, nan],
        [ 0.,  0.,  0., ..., nan, nan, nan],
        [ 0.,  0.,  0., ..., nan, nan, nan],
        ...,
        [ 0.,  0.,  0., ..., nan, nan, nan],
        [ 0.,  0.,  0., ..., nan, nan, nan],
        [ 0.,  0.,  0., ..., nan, nan, nan]]])
```