### PR TITLE
Feature Update: Retry logic for the ee.data.computePixels update.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -204,8 +204,9 @@ class EarthEngineStore(common.AbstractDataStore):
       executor_kwargs = {}
     self.executor_kwargs = executor_kwargs
 
-    self.tile_fetch_max_retries = tile_fetch_kwargs['max_retries']
-    self.tile_fetch_initial_delay = tile_fetch_kwargs['initial_delay']
+    # Default value: (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
+    self.tile_fetch_max_retries = tile_fetch_kwargs.pop('max_retries', 6)
+    self.tile_fetch_initial_delay = tile_fetch_kwargs.pop('initial_delay', 500)
 
     self.image_collection = image_collection
     if n_images != -1:

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -1053,10 +1053,10 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
         the ThreadPoolExecutor that handles the parallel computation of pixels
         i.e. {'max_workers': 2}.
       compute_pixels_max_retries (int): The maximum number of retry
-        attempts for calling ee.data.computePixels(). defaults to 6.
+        attempts for calling ee.data.computePixels(). By default, it is 6.
         # (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
       compute_pixels_initial_delay (int): The initial delay in milliseconds
-        before the first retry of calling ee.data.computePixels(). defaults to 500.
+        before the first retry of calling ee.data.computePixels(). By default, it is 500.
 
     Returns:
       An xarray.Dataset that streams in remote data from Earth Engine.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -1051,13 +1051,11 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       executor_kwargs (optional): A dictionary of keyword arguments to pass to
         the ThreadPoolExecutor that handles the parallel computation of pixels
         i.e. {'max_workers': 2}.
-      getitem_kwargs (optional): Exponential backoff kwargs passed into
-        the xarray function to index the array (`robust_getitem`).
-        i.e. {'max_retries' : 6, 'initial_delay': 500}.
-        - max_retries, the maximum number of retry attempts.By default, it is 6.
-        - initial_delay, the initial delay in milliseconds before the first
-        retry. By default, it is 500.
-        (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
+      getitem_kwargs (optional): Exponential backoff kwargs passed into the
+        xarray function to index the array (`robust_getitem`).
+        - 'max_retries', the maximum number of retry attempts. Defaults to 6.
+        - 'initial_delay', the initial delay in milliseconds before the first
+          retry. Defaults to 500.
     Returns:
       An xarray.Dataset that streams in remote data from Earth Engine.
     """

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -147,8 +147,8 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      compute_pixels_max_retries: Optional[int] = None,
-      compute_pixels_initial_delay: Optional[int] = None,
+      compute_pixels_max_retries: int = 6,
+      compute_pixels_initial_delay: int = 500,
   ) -> 'EarthEngineStore':
     if mode != 'r':
       raise ValueError(
@@ -190,8 +190,8 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      compute_pixels_max_retries: Optional[int] = None,
-      compute_pixels_initial_delay: Optional[int] = None,
+      compute_pixels_max_retries: int = 6,
+      compute_pixels_initial_delay: int = 500,
   ):
     self.ee_init_kwargs = ee_init_kwargs
     self.ee_init_if_necessary = ee_init_if_necessary
@@ -201,16 +201,8 @@ class EarthEngineStore(common.AbstractDataStore):
       executor_kwargs = {}
     self.executor_kwargs = executor_kwargs
 
-    # Here 6 & 500 is default value.
-    # (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
-    self.compute_pixels_max_retries = (
-        6 if compute_pixels_max_retries is None else compute_pixels_max_retries
-    )
-    self.compute_pixels_initial_delay = (
-        500
-        if compute_pixels_initial_delay is None
-        else compute_pixels_initial_delay
-    )
+    self.compute_pixels_max_retries = compute_pixels_max_retries
+    self.compute_pixels_initial_delay = compute_pixels_initial_delay
 
     self.image_collection = image_collection
     if n_images != -1:
@@ -986,8 +978,8 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       ee_init_if_necessary: bool = False,
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      compute_pixels_max_retries: Optional[int] = None,
-      compute_pixels_initial_delay: Optional[int] = None,
+      compute_pixels_max_retries: int = 6,
+      compute_pixels_initial_delay: int = 500,
   ) -> xarray.Dataset:  # type: ignore
     """Open an Earth Engine ImageCollection as an Xarray Dataset.
 
@@ -1060,10 +1052,11 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       executor_kwargs (optional): A dictionary of keyword arguments to pass to
         the ThreadPoolExecutor that handles the parallel computation of pixels
         i.e. {'max_workers': 2}.
-      compute_pixels_max_retries (optional):  The maximum number of retry
-        attempts for calling ee.data.computePixels().
-      compute_pixels_initial_delay (optional): The initial delay in milliseconds
-        before the first retry of calling ee.data.computePixels().
+      compute_pixels_max_retries (int): The maximum number of retry
+        attempts for calling ee.data.computePixels(). defaults to 6.
+        # (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
+      compute_pixels_initial_delay (int): The initial delay in milliseconds
+        before the first retry of calling ee.data.computePixels(). defaults to 500.
 
     Returns:
       An xarray.Dataset that streams in remote data from Earth Engine.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -147,8 +147,10 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      compute_pixels_max_retries: int = 6,
-      compute_pixels_initial_delay: int = 500,
+      tile_fetch_kwargs: Dict[str, int] = {
+          'max_retries': 6,
+          'initial_delay': 500,
+      },
   ) -> 'EarthEngineStore':
     if mode != 'r':
       raise ValueError(
@@ -170,8 +172,7 @@ class EarthEngineStore(common.AbstractDataStore):
         ee_init_kwargs=ee_init_kwargs,
         ee_init_if_necessary=ee_init_if_necessary,
         executor_kwargs=executor_kwargs,
-        compute_pixels_max_retries=compute_pixels_max_retries,
-        compute_pixels_initial_delay=compute_pixels_initial_delay,
+        tile_fetch_kwargs=tile_fetch_kwargs,
     )
 
   def __init__(
@@ -190,8 +191,10 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      compute_pixels_max_retries: int = 6,
-      compute_pixels_initial_delay: int = 500,
+      tile_fetch_kwargs: Dict[str, int] = {
+          'max_retries': 6,
+          'initial_delay': 500,
+      },
   ):
     self.ee_init_kwargs = ee_init_kwargs
     self.ee_init_if_necessary = ee_init_if_necessary
@@ -201,8 +204,8 @@ class EarthEngineStore(common.AbstractDataStore):
       executor_kwargs = {}
     self.executor_kwargs = executor_kwargs
 
-    self.compute_pixels_max_retries = compute_pixels_max_retries
-    self.compute_pixels_initial_delay = compute_pixels_initial_delay
+    self.tile_fetch_max_retries = tile_fetch_kwargs['max_retries']
+    self.tile_fetch_initial_delay = tile_fetch_kwargs['initial_delay']
 
     self.image_collection = image_collection
     if n_images != -1:
@@ -494,8 +497,8 @@ class EarthEngineStore(common.AbstractDataStore):
         pixels_getter,
         params,
         catch=ee.ee_exception.EEException,
-        max_retries=self.compute_pixels_max_retries,
-        initial_delay=self.compute_pixels_initial_delay,
+        max_retries=self.tile_fetch_max_retries,
+        initial_delay=self.tile_fetch_initial_delay,
     )
 
     # Extract out the shape information from EE response.
@@ -978,8 +981,10 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       ee_init_if_necessary: bool = False,
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      compute_pixels_max_retries: int = 6,
-      compute_pixels_initial_delay: int = 500,
+      tile_fetch_kwargs: Dict[str, int] = {
+          'max_retries': 6,
+          'initial_delay': 500,
+      },
   ) -> xarray.Dataset:  # type: ignore
     """Open an Earth Engine ImageCollection as an Xarray Dataset.
 
@@ -1052,12 +1057,14 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       executor_kwargs (optional): A dictionary of keyword arguments to pass to
         the ThreadPoolExecutor that handles the parallel computation of pixels
         i.e. {'max_workers': 2}.
-      compute_pixels_max_retries (int): The maximum number of retry
-        attempts for calling ee.data.computePixels(). By default, it is 6.
-        # (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
-      compute_pixels_initial_delay (int): The initial delay in milliseconds
-        before the first retry of calling ee.data.computePixels(). By default, it is 500.
-
+      tile_fetch_kwargs (Dict): The necessary kwargs like `max_retries`,
+        `initial_delay` which helps while fetching data through calling
+        ee.data.computePixels(). i.e. {'max_retries' : 6, 'initial_delay': 500}.
+        - max_retries is maximum number of retry attempts for calling
+        ee.data.computePixels().By default, it is 6.
+        - initial_delay is the initial delay in milliseconds before the first
+        retry of calling ee.data.computePixels(). By default, it is 500.
+        (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
     Returns:
       An xarray.Dataset that streams in remote data from Earth Engine.
     """
@@ -1087,8 +1094,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
         ee_init_kwargs=ee_init_kwargs,
         ee_init_if_necessary=ee_init_if_necessary,
         executor_kwargs=executor_kwargs,
-        compute_pixels_max_retries=compute_pixels_max_retries,
-        compute_pixels_initial_delay=compute_pixels_initial_delay,
+        tile_fetch_kwargs=tile_fetch_kwargs,
     )
 
     store_entrypoint = backends_store.StoreBackendEntrypoint()

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -152,7 +152,7 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      tile_fetch_kwargs: Dict[str, int] = TILE_FETCH_KWARGS,
+      tile_fetch_kwargs: Optional[Dict[str, int]] = None,
   ) -> 'EarthEngineStore':
     if mode != 'r':
       raise ValueError(
@@ -193,7 +193,7 @@ class EarthEngineStore(common.AbstractDataStore):
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       ee_init_if_necessary: bool = False,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      tile_fetch_kwargs: Dict[str, int] = TILE_FETCH_KWARGS,
+      tile_fetch_kwargs: Optional[Dict[str, int]] = None,
   ):
     self.ee_init_kwargs = ee_init_kwargs
     self.ee_init_if_necessary = ee_init_if_necessary
@@ -203,7 +203,11 @@ class EarthEngineStore(common.AbstractDataStore):
       executor_kwargs = {}
     self.executor_kwargs = executor_kwargs
 
-    self.tile_fetch_kwargs = tile_fetch_kwargs
+    self.tile_fetch_kwargs = (
+        self.TILE_FETCH_KWARGS
+        if tile_fetch_kwargs is None
+        else tile_fetch_kwargs
+    )
 
     self.image_collection = image_collection
     if n_images != -1:
@@ -983,10 +987,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       ee_init_if_necessary: bool = False,
       ee_init_kwargs: Optional[Dict[str, Any]] = None,
       executor_kwargs: Optional[Dict[str, Any]] = None,
-      tile_fetch_kwargs: Dict[str, int] = {
-          'max_retries': 6,
-          'initial_delay': 500,
-      },
+      tile_fetch_kwargs: Optional[Dict[str, int]] = None,
   ) -> xarray.Dataset:  # type: ignore
     """Open an Earth Engine ImageCollection as an Xarray Dataset.
 
@@ -1059,7 +1060,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       executor_kwargs (optional): A dictionary of keyword arguments to pass to
         the ThreadPoolExecutor that handles the parallel computation of pixels
         i.e. {'max_workers': 2}.
-      tile_fetch_kwargs (Dict): The necessary kwargs like `max_retries`,
+      tile_fetch_kwargs (optional): The necessary kwargs like `max_retries`,
         `initial_delay` which helps while fetching data through calling
         ee.data.computePixels(). i.e. {'max_retries' : 6, 'initial_delay': 500}.
         - max_retries is maximum number of retry attempts for calling

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -495,8 +495,7 @@ class EarthEngineStore(common.AbstractDataStore):
         pixels_getter,
         params,
         catch=ee.ee_exception.EEException,
-        max_retries=self.getitem_kwargs['max_retries'],
-        initial_delay=self.getitem_kwargs['initial_delay'],
+        **self.getitem_kwargs,
     )
 
     # Extract out the shape information from EE response.
@@ -1055,10 +1054,9 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       getitem_kwargs (optional): Exponential backoff kwargs passed into
         the xarray function to index the array (`robust_getitem`).
         i.e. {'max_retries' : 6, 'initial_delay': 500}.
-        - max_retries is maximum number of retry attempts for calling
-        ee.data.computePixels().By default, it is 6.
-        - initial_delay is the initial delay in milliseconds before the first
-        retry of calling ee.data.computePixels(). By default, it is 500.
+        - max_retries, the maximum number of retry attempts.By default, it is 6.
+        - initial_delay, the initial delay in milliseconds before the first
+        retry. By default, it is 500.
         (https://github.com/pydata/xarray/blob/main/xarray/backends/common.py#L181).
     Returns:
       An xarray.Dataset that streams in remote data from Earth Engine.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -1060,7 +1060,7 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
       executor_kwargs (optional): A dictionary of keyword arguments to pass to
         the ThreadPoolExecutor that handles the parallel computation of pixels
         i.e. {'max_workers': 2}.
-      compute_pixels_max_retries (optional):  The maximum number of retry 
+      compute_pixels_max_retries (optional):  The maximum number of retry
         attempts for calling ee.data.computePixels().
       compute_pixels_initial_delay (optional): The initial delay in milliseconds
         before the first retry of calling ee.data.computePixels().

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -69,7 +69,7 @@ class EEBackendArrayTest(absltest.TestCase):
             '2017-01-01', '2017-01-03'
         ),
         n_images=64,
-        tile_fetch_kwargs={'max_retries': 10, 'initial_delay': 1500},
+        getitem_kwargs={'max_retries': 10, 'initial_delay': 1500},
     )
     self.lnglat_store = xee.EarthEngineStore(
         ee.ImageCollection.fromImages([ee.Image.pixelLonLat()]),
@@ -81,7 +81,7 @@ class EEBackendArrayTest(absltest.TestCase):
             '2020-03-30', '2020-04-01'
         ),
         n_images=64,
-        tile_fetch_kwargs={'max_retries': 9},
+        getitem_kwargs={'max_retries': 9},
     )
     self.all_img_store = xee.EarthEngineStore(
         ee.ImageCollection('LANDSAT/LC08/C01/T1').filterDate(
@@ -257,18 +257,18 @@ class EEBackendArrayTest(absltest.TestCase):
 
     self.assertEqual(getter.count, 3)
 
-  def test_tile_fetch_kwargs(self):
+  def test_getitem_kwargs(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
-    self.assertEqual(arr.store.tile_fetch_kwargs['initial_delay'], 1500)
-    self.assertEqual(arr.store.tile_fetch_kwargs['max_retries'], 10)
+    self.assertEqual(arr.store.getitem_kwargs['initial_delay'], 1500)
+    self.assertEqual(arr.store.getitem_kwargs['max_retries'], 10)
 
     arr1 = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
-    self.assertEqual(arr1.store.tile_fetch_kwargs['initial_delay'], 500)
-    self.assertEqual(arr1.store.tile_fetch_kwargs['max_retries'], 6)
+    self.assertEqual(arr1.store.getitem_kwargs['initial_delay'], 500)
+    self.assertEqual(arr1.store.getitem_kwargs['max_retries'], 6)
 
-    arr1 = xee.EarthEngineBackendArray('spi2y', self.conus_store)
-    self.assertNotIn('initial_delay', arr1.store.tile_fetch_kwargs)
-    self.assertEqual(arr1.store.tile_fetch_kwargs['max_retries'], 9)
+    arr2 = xee.EarthEngineBackendArray('spi2y', self.conus_store)
+    self.assertEqual(arr2.store.getitem_kwargs['initial_delay'], 500)
+    self.assertEqual(arr2.store.getitem_kwargs['max_retries'], 9)
 
 
 class EEBackendEntrypointTest(absltest.TestCase):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -69,6 +69,7 @@ class EEBackendArrayTest(absltest.TestCase):
             '2017-01-01', '2017-01-03'
         ),
         n_images=64,
+        tile_fetch_kwargs={'max_retries': 10, 'initial_delay': 1500},
     )
     self.lnglat_store = xee.EarthEngineStore(
         ee.ImageCollection.fromImages([ee.Image.pixelLonLat()]),
@@ -254,6 +255,15 @@ class EEBackendArrayTest(absltest.TestCase):
     )
 
     self.assertEqual(getter.count, 3)
+
+  def test_tile_fetch_kwargs(self):
+    arr = xee.EarthEngineBackendArray('B4', self.store)
+    self.assertEqual(arr.store.tile_fetch_initial_delay, 1500)
+    self.assertEqual(arr.store.tile_fetch_max_retries, 10)
+
+    arr1 = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
+    self.assertEqual(arr1.store.tile_fetch_initial_delay, 500)
+    self.assertEqual(arr1.store.tile_fetch_max_retries, 6)
 
 
 class EEBackendEntrypointTest(absltest.TestCase):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -81,6 +81,7 @@ class EEBackendArrayTest(absltest.TestCase):
             '2020-03-30', '2020-04-01'
         ),
         n_images=64,
+        tile_fetch_kwargs={'max_retries': 9},
     )
     self.all_img_store = xee.EarthEngineStore(
         ee.ImageCollection('LANDSAT/LC08/C01/T1').filterDate(
@@ -258,13 +259,16 @@ class EEBackendArrayTest(absltest.TestCase):
 
   def test_tile_fetch_kwargs(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
-    self.assertEqual(arr.store.tile_fetch_initial_delay, 1500)
-    self.assertEqual(arr.store.tile_fetch_max_retries, 10)
+    self.assertEqual(arr.store.tile_fetch_kwargs['initial_delay'], 1500)
+    self.assertEqual(arr.store.tile_fetch_kwargs['max_retries'], 10)
 
     arr1 = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
-    self.assertEqual(arr1.store.tile_fetch_initial_delay, 500)
-    self.assertEqual(arr1.store.tile_fetch_max_retries, 6)
+    self.assertEqual(arr1.store.tile_fetch_kwargs['initial_delay'], 500)
+    self.assertEqual(arr1.store.tile_fetch_kwargs['max_retries'], 6)
 
+    arr1 = xee.EarthEngineBackendArray('spi2y', self.conus_store)
+    self.assertNotIn('initial_delay', arr1.store.tile_fetch_kwargs)
+    self.assertEqual(arr1.store.tile_fetch_kwargs['max_retries'], 9)
 
 class EEBackendEntrypointTest(absltest.TestCase):
 

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -270,6 +270,7 @@ class EEBackendArrayTest(absltest.TestCase):
     self.assertNotIn('initial_delay', arr1.store.tile_fetch_kwargs)
     self.assertEqual(arr1.store.tile_fetch_kwargs['max_retries'], 9)
 
+
 class EEBackendEntrypointTest(absltest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
Xee always used the default value of the `max_retries`, `initial_delay` while calling the `ee.data.computePixels()` through the [robust_getitem](https://github.com/google/Xee/blob/main/xee/ext.py#L484) which affects the QPS(queries per second). To provide Xee users with more control over the QPS, these two variables are now configurable within Xee and can be set by users as well.