### PR TITLE
Support for the positive scale in xee added.

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -431,21 +431,49 @@ class EarthEngineStore(common.AbstractDataStore):
         projection and scale.
     """
     # The origin of the image is in the top left corner. X and Y is the minimum value.
-    x_origin, y_origin, _, _ = self.bounds  # x_min, y_min, x_max, y_max
+    print("Self.scale_x, : ", self.scale_x, self.scale_y)
+    print("self.bounds : ", self.bounds)
+    print("bbox is this : ", bbox)
+    x_origin, y_origin, x_origin1, y_origin1 = self.bounds  # x_min, y_min, x_max, y_max
     x_start, y_start, x_end, y_end = bbox
     width = x_end - x_start
     height = y_end - y_start
+    # points consider after taking the origin from the both side.
+    # translateX = (
+    #     x_origin + self.scale_x * x_start
+    #     if self.scale_x > 0
+    #     else x_origin + abs(self.scale_x) * x_end
+    # )
+    # translateY = (
+    #     y_origin + self.scale_y * y_start
+    #     if self.scale_y > 0
+    #     else y_origin1 + self.scale_y * y_end
+    # )
+
+    # # Points consider after taking below points as a origin
+    # translateX = (
+    #     x_origin + self.scale_x * x_start
+    #     if self.scale_x > 0
+    #     else x_origin + abs(self.scale_x) * x_end
+    # )
+    # translateY = (
+    #     y_origin + self.scale_y * y_start
+    #     if self.scale_y > 0
+    #     else y_origin + abs(self.scale_y) * y_end
+    # )
+
+    # Points consider after taking above points as a origin
     translateX = (
-        x_origin + self.scale_x * x_start
+        x_origin1 - self.scale_x * x_end
         if self.scale_x > 0
-        else x_origin + abs(self.scale_x) * x_end
+        else x_origin1 + abs(self.scale_x) * x_start
     )
     translateY = (
-        y_origin + self.scale_y * y_start
+        y_origin1 - self.scale_y * y_end
         if self.scale_y > 0
-        else y_origin + abs(self.scale_y) * y_end
+        else y_origin1 + abs(self.scale_y) * y_start
     )
-
+    print("translateY is this : ",translateX, translateY)
     return {
         # The size of the bounding box. The affine transform and project will be
         # applied, so we can think in terms of pixels.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -427,10 +427,10 @@ class EarthEngineStore(common.AbstractDataStore):
 
     # Find the actual coordinates of the first or last point of the bounding box
     # (bbox) based on the positive and negative scale in the actual Earth Engine
-    # (EE) image. Since EE bounding boxes can be flipped (negative scale), we 
+    # (EE) image. Since EE bounding boxes can be flipped (negative scale), we
     # cannot determine the origin (transform translation) simply by identifying
     # the min and max extents. Instead, we calculate the translation by
-    # considering the direction of scaling (positive or negative) along both 
+    # considering the direction of scaling (positive or negative) along both
     # the x and y axes.
     translateX = self.scale_x * x_start + (x_min if self.scale_x > 0 else x_max)
     translateY = self.scale_y * y_start + (y_min if self.scale_y > 0 else y_max)

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -421,7 +421,7 @@ class EarthEngineStore(common.AbstractDataStore):
         projection and scale.
     """
     # The origin of the image is in the top left corner.
-    x_min, y_min, _, _ = self.bounds
+    x_min, y_min, x_max, y_max = self.bounds
     x_start, y_start, x_end, y_end = bbox
     width = x_end - x_start
     height = y_end - y_start
@@ -430,12 +430,12 @@ class EarthEngineStore(common.AbstractDataStore):
     translateX = (
         x_min + x_start * self.scale_x
         if self.scale_x > 0
-        else x_min + (-1 * self.scale_x * x_end)
+        else x_max + self.scale_x * x_start
     )
     translateY = (
         y_min + y_start * self.scale_y
         if self.scale_y > 0
-        else y_min + (-1 * self.scale_y * y_end)
+        else y_max + self.scale_y * y_start
     )
     return {
         # The size of the bounding box. The affine transform and project will be

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -432,8 +432,12 @@ class EarthEngineStore(common.AbstractDataStore):
     # the min and max extents. Instead, we calculate the translation by
     # considering the direction of scaling (positive or negative) along both
     # the x and y axes.
-    translate_x = self.scale_x * x_start + (x_min if self.scale_x > 0 else x_max)
-    translate_y = self.scale_y * y_start + (y_min if self.scale_y > 0 else y_max)
+    translate_x = self.scale_x * x_start + (
+        x_min if self.scale_x > 0 else x_max
+    )
+    translate_y = self.scale_y * y_start + (
+        y_min if self.scale_y > 0 else y_max
+    )
 
     return {
         # The size of the bounding box. The affine transform and project will be

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -430,14 +430,14 @@ class EarthEngineStore(common.AbstractDataStore):
         appropriate region of data to return according to the Array's configured
         projection and scale.
     """
-    # The origin of the image is in the top left corner. X and Y is the minimum value.
-    x_origin, y_origin, x_origin1, y_origin1 = self.bounds  # x_min, y_min, x_max, y_max
+    # The origin of the image is in the top left corner.
+    x_min, y_min, x_max, y_max = self.bounds
     x_start, y_start, x_end, y_end = bbox
     width = x_end - x_start
     height = y_end - y_start
 
-    translateX = x_origin if self.scale_x > 0 else x_origin1
-    translateY = y_origin if self.scale_y > 0 else y_origin1
+    translateX = x_min if self.scale_x > 0 else x_max
+    translateY = y_min if self.scale_y > 0 else y_max
     return {
         # The size of the bounding box. The affine transform and project will be
         # applied, so we can think in terms of pixels.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -425,12 +425,13 @@ class EarthEngineStore(common.AbstractDataStore):
     width = x_end - x_start
     height = y_end - y_start
 
-    # Find the actual coordinates of the first or last point of the bounding box (bbox)
-    # based on the positive and negative scale in the actual Earth Engine (EE) image.
-    # Since EE bounding boxes can be flipped (negative scale), we cannot determine
-    # the origin (transform translation) simply by identifying the min and max extents.
-    # Instead, we calculate the translation by considering the direction of scaling
-    # (positive or negative) along both the x and y axes.
+    # Find the actual coordinates of the first or last point of the bounding box
+    # (bbox) based on the positive and negative scale in the actual Earth Engine
+    # (EE) image. Since EE bounding boxes can be flipped (negative scale), we 
+    # cannot determine the origin (transform translation) simply by identifying
+    # the min and max extents. Instead, we calculate the translation by
+    # considering the direction of scaling (positive or negative) along both 
+    # the x and y axes.
     translateX = self.scale_x * x_start + (x_min if self.scale_x > 0 else x_max)
     translateY = self.scale_y * y_start + (y_min if self.scale_y > 0 else y_max)
 

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -312,14 +312,16 @@ class EarthEngineStore(common.AbstractDataStore):
     # client-side. Ideally, this would live behind a xarray-backend-specific
     # feature flag, since it's not guaranteed that data is this consistent.
     columns = ['system:id', self.primary_dim_property]
-    rpcs.append((
-        'properties',
+    rpcs.append(
         (
-            self.image_collection.reduceColumns(
-                ee.Reducer.toList().repeat(len(columns)), columns
-            ).get('list')
-        ),
-    ))
+            'properties',
+            (
+                self.image_collection.reduceColumns(
+                    ee.Reducer.toList().repeat(len(columns)), columns
+                ).get('list')
+            ),
+        )
+    )
 
     info = ee.List([rpc for _, rpc in rpcs]).getInfo()
 

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -431,49 +431,13 @@ class EarthEngineStore(common.AbstractDataStore):
         projection and scale.
     """
     # The origin of the image is in the top left corner. X and Y is the minimum value.
-    print("Self.scale_x, : ", self.scale_x, self.scale_y)
-    print("self.bounds : ", self.bounds)
-    print("bbox is this : ", bbox)
     x_origin, y_origin, x_origin1, y_origin1 = self.bounds  # x_min, y_min, x_max, y_max
     x_start, y_start, x_end, y_end = bbox
     width = x_end - x_start
     height = y_end - y_start
-    # points consider after taking the origin from the both side.
-    # translateX = (
-    #     x_origin + self.scale_x * x_start
-    #     if self.scale_x > 0
-    #     else x_origin + abs(self.scale_x) * x_end
-    # )
-    # translateY = (
-    #     y_origin + self.scale_y * y_start
-    #     if self.scale_y > 0
-    #     else y_origin1 + self.scale_y * y_end
-    # )
 
-    # # Points consider after taking below points as a origin
-    # translateX = (
-    #     x_origin + self.scale_x * x_start
-    #     if self.scale_x > 0
-    #     else x_origin + abs(self.scale_x) * x_end
-    # )
-    # translateY = (
-    #     y_origin + self.scale_y * y_start
-    #     if self.scale_y > 0
-    #     else y_origin + abs(self.scale_y) * y_end
-    # )
-
-    # Points consider after taking above points as a origin
-    translateX = (
-        x_origin1 - self.scale_x * x_end
-        if self.scale_x > 0
-        else x_origin1 + abs(self.scale_x) * x_start
-    )
-    translateY = (
-        y_origin1 - self.scale_y * y_end
-        if self.scale_y > 0
-        else y_origin1 + abs(self.scale_y) * y_start
-    )
-    print("translateY is this : ",translateX, translateY)
+    translateX = x_origin if self.scale_x > 0 else x_origin1
+    translateY = y_origin if self.scale_y > 0 else y_origin1
     return {
         # The size of the bounding box. The affine transform and project will be
         # applied, so we can think in terms of pixels.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -420,23 +420,20 @@ class EarthEngineStore(common.AbstractDataStore):
         appropriate region of data to return according to the Array's configured
         projection and scale.
     """
-    # The origin of the image is in the top left corner.
     x_min, y_min, x_max, y_max = self.bounds
     x_start, y_start, x_end, y_end = bbox
     width = x_end - x_start
     height = y_end - y_start
 
-    # Found the actual coordinates of the first or last point of the bbox based on the pos & neg scale in the actual image.
-    translateX = (
-        x_min + x_start * self.scale_x
-        if self.scale_x > 0
-        else x_max + self.scale_x * x_start
-    )
-    translateY = (
-        y_min + y_start * self.scale_y
-        if self.scale_y > 0
-        else y_max + self.scale_y * y_start
-    )
+    # Find the actual coordinates of the first or last point of the bounding box (bbox)
+    # based on the positive and negative scale in the actual Earth Engine (EE) image.
+    # Since EE bounding boxes can be flipped (negative scale), we cannot determine
+    # the origin (transform translation) simply by identifying the min and max extents.
+    # Instead, we calculate the translation by considering the direction of scaling
+    # (positive or negative) along both the x and y axes.
+    translateX = self.scale_x * x_start + (x_min if self.scale_x > 0 else x_max)
+    translateY = self.scale_y * y_start + (y_min if self.scale_y > 0 else y_max)
+
     return {
         # The size of the bounding box. The affine transform and project will be
         # applied, so we can think in terms of pixels.

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -432,8 +432,8 @@ class EarthEngineStore(common.AbstractDataStore):
     # the min and max extents. Instead, we calculate the translation by
     # considering the direction of scaling (positive or negative) along both
     # the x and y axes.
-    translateX = self.scale_x * x_start + (x_min if self.scale_x > 0 else x_max)
-    translateY = self.scale_y * y_start + (y_min if self.scale_y > 0 else y_max)
+    translate_x = self.scale_x * x_start + (x_min if self.scale_x > 0 else x_max)
+    translate_y = self.scale_y * y_start + (y_min if self.scale_y > 0 else y_max)
 
     return {
         # The size of the bounding box. The affine transform and project will be
@@ -443,8 +443,8 @@ class EarthEngineStore(common.AbstractDataStore):
             'height': height,
         },
         'affineTransform': {
-            'translateX': translateX,
-            'translateY': translateY,
+            'translateX': translate_x,
+            'translateY': translate_y,
             # Define the scale for each pixel (e.g. the number of meters between
             # each value).
             'scaleX': self.scale_x,

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -308,11 +308,11 @@ class EEBackendEntrypointTest(absltest.TestCase):
     # Should not be able to open a feature collection.
     self.assertFalse(self.entry.guess_can_open('WRI/GPPD/power_plants'))
 
-  def test_open_dataset__sanity_check(self):
+  def test_open_dataset__sanity_check_with_positive_scale(self):
     ds = self.entry.open_dataset(
         pathlib.Path('LANDSAT') / 'LC08' / 'C01' / 'T1',
         drop_variables=tuple(f'B{i}' for i in range(3, 12)),
-        projection = ee.Projection('EPSG:4326', [25, 0, 0, 0, -25, 0]),
+        scale=25.0,  # in degrees
         n_images=3,
     )
     self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
@@ -323,7 +323,25 @@ class EEBackendEntrypointTest(absltest.TestCase):
     )
     for v in ds.values():
       self.assertIsNotNone(v.data)
-      self.assertFalse(v.isnull().all(), 'All values are null!')
+      self.assertTrue(v.isnull().all(), 'All values must be null!')
+      self.assertEqual(v.shape, (3, 14, 7))
+
+  def test_open_dataset__sanity_check_with_negative_scale(self):
+    ds = self.entry.open_dataset(
+        pathlib.Path('LANDSAT') / 'LC08' / 'C01' / 'T1',
+        drop_variables=tuple(f'B{i}' for i in range(3, 12)),
+        scale=-25.0,  # in degrees
+        n_images=3,
+    )
+    self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
+    self.assertNotEmpty(dict(ds.coords))
+    self.assertEqual(
+        list(ds.data_vars.keys()),
+        [f'B{i}' for i in range(1, 3)] + ['BQA'],
+    )
+    for v in ds.values():
+      self.assertIsNotNone(v.data)
+      self.assertTrue(v.isnull().all(), 'All values must be null!')
       self.assertEqual(v.shape, (3, 14, 7))
 
   def test_open_dataset__n_images(self):

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -536,7 +536,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
           engine=xee.EarthEngineBackendEntrypoint,
           crs=crs,
           geometry=geom,
-          projection=ee.Projection(crs, [10, 0, 0, 0, -10, 0]),
+          projection=ee.Projection('EPSG:4326', [10, 0, 0, 0, -10, 0]),
       )
 
       ds = ds.isel(time=0).transpose('Y', 'X')

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -469,7 +469,6 @@ class EEBackendEntrypointTest(absltest.TestCase):
       ds = xr.open_dataset(
           col,
           engine=xee.EarthEngineBackendEntrypoint,
-          scale=10,
           crs=crs,
           geometry=geom,
           projection=ee.Projection(crs, [10, 0, 0, 0, -10, 0]),

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -312,7 +312,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     ds = self.entry.open_dataset(
         pathlib.Path('LANDSAT') / 'LC08' / 'C01' / 'T1',
         drop_variables=tuple(f'B{i}' for i in range(3, 12)),
-        scale=25.0,  # in degrees
+        projection = ee.Projection('EPSG:4326', [25, 0, 0, 0, -25, 0]),
         n_images=3,
     )
     self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -472,7 +472,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
           scale=10,
           crs=crs,
           geometry=geom,
-          projection= ee.Projection(crs, [10, 0, 0, 0, -10, 0])
+          projection=ee.Projection(crs, [10, 0, 0, 0, -10, 0]),
       )
 
       ds = ds.isel(time=0).transpose('Y', 'X')
@@ -508,7 +508,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
           col,
           engine=xee.EarthEngineBackendEntrypoint,
           geometry=geom,
-          projection= ee.Projection('EPSG:4326', [0.0025, 0, 0, 0, -0.0025, 0])
+          projection=ee.Projection('EPSG:4326', [0.0025, 0, 0, 0, -0.0025, 0]),
       )
 
       ds = ds.isel(time=0).transpose('lat', 'lon')

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -472,6 +472,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
           scale=10,
           crs=crs,
           geometry=geom,
+          projection= ee.Projection(crs, [10, 0, 0, 0, -10, 0])
       )
 
       ds = ds.isel(time=0).transpose('Y', 'X')
@@ -506,8 +507,8 @@ class EEBackendEntrypointTest(absltest.TestCase):
       ds = xr.open_dataset(
           col,
           engine=xee.EarthEngineBackendEntrypoint,
-          scale=0.0025,
           geometry=geom,
+          projection= ee.Projection('EPSG:4326', [0.0025, 0, 0, 0, -0.0025, 0])
       )
 
       ds = ds.isel(time=0).transpose('lat', 'lon')

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -334,7 +334,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     # Should not be able to open a feature collection.
     self.assertFalse(self.entry.guess_can_open('WRI/GPPD/power_plants'))
 
-  def test_open_dataset__sanity_check_with_negative_projection(self):
+  def test_open_dataset__sanity_check(self):
     ds = self.entry.open_dataset(
         pathlib.Path('LANDSAT') / 'LC08' / 'C01' / 'T1',
         drop_variables=tuple(f'B{i}' for i in range(3, 12)),
@@ -349,25 +349,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     )
     for v in ds.values():
       self.assertIsNotNone(v.data)
-      self.assertTrue(v.isnull().all(), 'All values are null!')
-      self.assertEqual(v.shape, (3, 14, 7))
-
-  def test_open_dataset__sanity_check_with_positive_scale(self):
-    ds = self.entry.open_dataset(
-        pathlib.Path('LANDSAT') / 'LC08' / 'C01' / 'T1',
-        drop_variables=tuple(f'B{i}' for i in range(3, 12)),
-        scale=25.0,  # in degrees
-        n_images=3,
-    )
-    self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
-    self.assertNotEmpty(dict(ds.coords))
-    self.assertEqual(
-        list(ds.data_vars.keys()),
-        [f'B{i}' for i in range(1, 3)] + ['BQA'],
-    )
-    for v in ds.values():
-      self.assertIsNotNone(v.data)
-      self.assertTrue(v.isnull().all(), 'All values must be null!')
+      self.assertFalse(v.isnull().all(), 'All values are null!')
       self.assertEqual(v.shape, (3, 14, 7))
 
   def test_open_dataset__sanity_check_with_negative_scale(self):


### PR DESCRIPTION
As indicated in the title, Xee **does not** work properly when the **positive scale** is passed. To address this, I have included a logic that can also operate on the positive scale.

The reference notebook, which includes all possible test cases, can be found here [Reference notebook](https://colab.research.google.com/drive/1pNQ5qCqT_SlQHFYIioRTI5By-8yGerZW?resourcekey=0-T6oVflx5Yw9xrfYWNQsD6A&usp=sharing)
