### PR TITLE
set the version number somewhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,7 @@ preview = true
 pyink-indentation = 2
 pyink-use-majority-quotes = true
 
+[tools.setuptools.dynamic]
+version = {attr = "xee.__version__"}
+
 [tool.setuptools_scm]

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -47,11 +47,7 @@ import ee
 
 
 assert sys.version_info >= (3, 8)
-try:
-  __version__ = importlib.metadata.version('xee') or 'unknown'
-except importlib.metadata.PackageNotFoundError:
-  __version__ = 'unknown'
-
+__version__ = "0.0.14"
 
 # Chunks type definition taken from Xarray
 # https://github.com/pydata/xarray/blob/f13da94db8ab4b564938a5e67435ac709698f1c9/xarray/core/types.py#L173


### PR DESCRIPTION
Fix #161 

My understanding of the problem is that the version number is not set anywhere. 

pyproject.toml uses a dynamic version number but the dynamic estination is not set, xee package has no __version__ variable. the one in `ext` is using the one from metadata which relies on the pyproject file. 

I decided to start this PR by setting where the dynamic version number should come from. Now I need your review to know where  the hard coded version number should be set.