### PR TITLE
Updating a way to find the Unit Property of the Coordinate Reference System (CRS).

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -234,7 +234,7 @@ class EarthEngineStore(common.AbstractDataStore):
 
     self.crs_arg = crs or proj.get('crs', proj.get('wkt', 'EPSG:4326'))
     self.crs = CRS(self.crs_arg)
-    
+
     is_crs_geographic = self.crs.is_geographic
     # Gets the unit i.e. meter, degree etc.
     self.scale_units = 'degree' if is_crs_geographic else 'meter'

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -234,8 +234,10 @@ class EarthEngineStore(common.AbstractDataStore):
 
     self.crs_arg = crs or proj.get('crs', proj.get('wkt', 'EPSG:4326'))
     self.crs = CRS(self.crs_arg)
+    
+    is_crs_geographic = self.crs.is_geographic
     # Gets the unit i.e. meter, degree etc.
-    self.scale_units = self.crs.axis_info[0].unit_name
+    self.scale_units = 'degree' if is_crs_geographic else 'meter'
     # Get the dimensions name based on the CRS (scale units).
     self.dimension_names = self.DIMENSION_NAMES.get(
         self.scale_units, ('X', 'Y')


### PR DESCRIPTION
The present code retrieves the unit of the CRS using the `crs[0].axis_info` method. However, a `previous version (2.4.2)` of `pyproj` does not provide the unit of the CRS when calling `crs[0].axis_info`. In the context of working Xee in an older version of the pyproj, we must modify this retrieval method.

Reference Code:
```
import ee
ee.Initialize()

import pyproj
from pyproj.crs import CRS

proj = pyproj.Proj(proj='eqc')
crs = pyproj.CRS.from_string(proj.definition_string())
wkt = crs.to_wkt('WKT1_GDAL')

projection = ee.Projection(wkt, [1, 0, 0, 0, -1, 0]).atScale(10000).getInfo()
wkt_str = projection.get('wkt')

crs = CRS(wkt_str)
print(crs.axis_info)
```
Running the aforementioned code with the older version of PyProj results in an empty list.