### PR TITLE
build: add a fallback version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,4 @@ pyink-indentation = 2
 pyink-use-majority-quotes = true
 
 [tool.setuptools_scm]
+fallback_version = "9999"


### PR DESCRIPTION
follow-up from #162. Let's see if this is sufficent for a conda release. 