### PR TITLE
drop example extra-requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,6 @@ dataflow = [
   "gcsfs<=2024.2.0",
   "xarray-beam",
 ]
-examples = [
-  "xee[dataflow]",
-]
 
 [project.urls]
 Homepage = "https://github.com/google/xee"


### PR DESCRIPTION
It's exactly the same as the dataflow one so let's keep it simple and only provide a "dataflow" one.