### PR TITLE
Only run CI tests if PR is not from a fork

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: "python ${{ matrix.python-version }} tests"
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
We have CI testing triggered on PRs. However, we don't want to expose auth-related secrets to run tests on forks, so auth fails by default on PRs coming from external contributors (see [here](https://github.com/google/Xee/actions/runs/10908377089/job/30416416034?pr=175)). We should detect if PR is from a fork and not run CI tests, if true. This PR adds this logic based on https://github.com/orgs/community/discussions/25217.