### PR TITLE
Convert ee.Image objects to ee.ImageCollection objects

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ cython_debug/
 
 # MacOS 
 .DS_Store
+
+# pixi environments
+.pixi

--- a/xee/ext.py
+++ b/xee/ext.py
@@ -1122,11 +1122,12 @@ class EarthEngineBackendEntrypoint(backends.BackendEntrypoint):
     if ee.data.getUserAgent() != user_agent:
       ee.data.setUserAgent(user_agent)
 
-    collection = (
-        filename_or_obj
-        if isinstance(filename_or_obj, ee.ImageCollection)
-        else ee.ImageCollection(self._parse(filename_or_obj))
-    )
+    if isinstance(filename_or_obj, ee.ImageCollection):
+      collection = filename_or_obj
+    elif isinstance(filename_or_obj, ee.Image):
+      collection = ee.ImageCollection(filename_or_obj)
+    else:
+      collection = ee.ImageCollection(self._parse(filename_or_obj))
 
     store = EarthEngineStore.open(
         collection,

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -382,6 +382,14 @@ class EEBackendEntrypointTest(absltest.TestCase):
 
     self.assertLen(ds.time, 1)
 
+  def test_open_dataset_image_to_imagecollection(self):
+    """Ensure that opening a ee.Image is the same as opening a single image ee.ImageCollection"""
+    img = ee.Image('CGIAR/SRTM90_V4')
+    ic = ee.ImageCollection(img)
+    ds1 = xr.open_dataset(img, engine='ee')
+    ds2 = xr.open_dataset(ic, engine='ee')
+    self.assertTrue(ds1.identical(ds2))
+
   def test_can_chunk__opened_dataset(self):
     ds = xr.open_dataset(
         'NASA/GPM_L3/IMERG_V07',

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -384,7 +384,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
 
   def test_can_chunk__opened_dataset(self):
     ds = xr.open_dataset(
-        'NASA/GPM_L3/IMERG_V06',
+        'NASA/GPM_L3/IMERG_V07',
         crs='EPSG:4326',
         scale=0.25,
         engine=xee.EarthEngineBackendEntrypoint,

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -341,7 +341,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         n_images=3,
         projection=ee.Projection('EPSG:4326', [25, 0, 0, 0, -25, 0]),
     )
-    self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
+    self.assertEqual(dict(ds.sizes), {'time': 3, 'lon': 14, 'lat': 7})
     self.assertNotEmpty(dict(ds.coords))
     self.assertEqual(
         list(ds.data_vars.keys()),
@@ -360,7 +360,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         scale=-25.0,  # in degrees
         n_images=3,
     )
-    self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
+    self.assertEqual(dict(ds.sizes), {'time': 3, 'lon': 14, 'lat': 7})
     self.assertNotEmpty(dict(ds.coords))
     self.assertEqual(
         list(ds.data_vars.keys()),
@@ -410,8 +410,8 @@ class EEBackendEntrypointTest(absltest.TestCase):
         engine=xee.EarthEngineBackendEntrypoint,
     )
 
-    self.assertEqual(ds.dims, {'time': 4248, 'lon': 40, 'lat': 35})
-    self.assertNotEqual(ds.dims, standard_ds.dims)
+    self.assertEqual(ds.sizes, {'time': 4248, 'lon': 40, 'lat': 35})
+    self.assertNotEqual(ds.sizes, standard_ds.sizes)
 
   def test_honors_projection(self):
     ic = ee.ImageCollection('ECMWF/ERA5_LAND/HOURLY').filterDate(
@@ -427,8 +427,8 @@ class EEBackendEntrypointTest(absltest.TestCase):
         engine=xee.EarthEngineBackendEntrypoint,
     )
 
-    self.assertEqual(ds.dims, {'time': 4248, 'lon': 3600, 'lat': 1800})
-    self.assertNotEqual(ds.dims, standard_ds.dims)
+    self.assertEqual(ds.sizes, {'time': 4248, 'lon': 3600, 'lat': 1800})
+    self.assertNotEqual(ds.sizes, standard_ds.sizes)
 
   @absltest.skipIf(_SKIP_RASTERIO_TESTS, 'rioxarray module not loaded')
   def test_expected_precise_transform(self):
@@ -476,14 +476,14 @@ class EEBackendEntrypointTest(absltest.TestCase):
         scale=25.0,  # in degrees
         n_images=3,
     )
-    self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
+    self.assertEqual(dict(ds.sizes), {'time': 3, 'lon': 14, 'lat': 7})
     ds = self.entry.open_dataset(
         'ee:LANDSAT/LC08/C02/T1',
         drop_variables=tuple(f'B{i}' for i in range(3, 12)),
         scale=25.0,  # in degrees
         n_images=3,
     )
-    self.assertEqual(dict(ds.dims), {'time': 3, 'lon': 14, 'lat': 7})
+    self.assertEqual(dict(ds.sizes), {'time': 3, 'lon': 14, 'lat': 7})
 
   def test_data_sanity_check(self):
     # This simple test uncovered a bug with the default definition of `scale`.

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -383,7 +383,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     self.assertLen(ds.time, 1)
 
   def test_open_dataset_image_to_imagecollection(self):
-    """Ensure that opening a ee.Image is the same as opening a single image ee.ImageCollection"""
+    """Ensure that opening an ee.Image is the same as opening a single image ee.ImageCollection."""
     img = ee.Image('CGIAR/SRTM90_V4')
     ic = ee.ImageCollection(img)
     ds1 = xr.open_dataset(img, engine='ee')


### PR DESCRIPTION
Fixes #190.
Adds an integration test.
Passes current integration tests:
```
% USE_ADC_CREDENTIALS=1 python -m unittest xee.ext_integration_test                        
.................................
----------------------------------------------------------------------
Ran 33 tests in 378.508s
```