### PR TITLE
Aways return geographic coordinates from ee.Geometry.bounds()

### DIFF
--- a/xee/ext.py
+++ b/xee/ext.py
@@ -291,14 +291,14 @@ class EarthEngineStore(common.AbstractDataStore):
       rpcs.append(('projection', self.projection))
 
     if isinstance(self.geometry, ee.Geometry):
-      rpcs.append(('bounds', self.geometry.bounds(1, proj=self.projection)))
+      rpcs.append(('bounds', self.geometry.bounds(1)))
     else:
       rpcs.append(
           (
               'bounds',
               self.image_collection.first()
               .geometry()
-              .bounds(1, proj=self.projection),
+              .bounds(1),
           )
       )
 


### PR DESCRIPTION
Fixes #198 

Aways return geographic coordinates from `ee.Geometry.bounds()` because the later call to [`pyproj.Transformer.from_crs`](https://github.com/google/Xee/blob/5ce8db60d8cf78c4967ee21016d802add1d4d3cb/xee/ext.py#L417) to get coordinates in the requested `crs` is expecting geographic (lat lon) coordinates. If a `projection` argument is provided, the current implementation wrongly returns the bounds of the request in the crs of the projection, it should be in EPSG:4326, which is what happens if a person specifies `crs` and `scale` instead of `projection` because `self.projection` is never set in this case and therefore `ee.Geometry.bounds()` defaults to `EPSG:4326`, which is fine.

See #198  for a repro/testing script.