### PR TITLE
Change dimension ordering from (time, x, y) to (time, y, x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ If you don't have it installed, you can add it with pip:
 pip install matplotlib
 ```
 
-Xarray's plotting functions work directly with the data, which now follows the standard `(y, x)` dimension ordering convention used by NetCDF-CF and matplotlib.
+Then you can use Xarray's plotting functions to visualize the data.
 
 ```python
 
@@ -232,7 +232,7 @@ ds = xr.open_dataset('ECMWF/ERA5_LAND/MONTHLY_AGGR', engine='ee', **grid_params)
 # Select the 2m air temperature for the first time step
 temp_slice = ds['temperature_2m'].isel(time=0)
 
-# Plot directly - no transpose needed!
+# Plot the data
 temp_slice.plot()
 ```
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ If you don't have it installed, you can add it with pip:
 pip install matplotlib
 ```
 
-Xarray's plotting functions expect dimensions in `(y, x)` order for 2D plots. Since the data is in `(x, y)` order, we use `.transpose()` to swap the axes for correct visualization.
+Xarray's plotting functions work directly with the data, which now follows the standard `(y, x)` dimension ordering convention used by NetCDF-CF and matplotlib.
 
 ```python
 
@@ -232,8 +232,8 @@ ds = xr.open_dataset('ECMWF/ERA5_LAND/MONTHLY_AGGR', engine='ee', **grid_params)
 # Select the 2m air temperature for the first time step
 temp_slice = ds['temperature_2m'].isel(time=0)
 
-# Transpose from (x, y) to (y, x) for correct plotting orientation and plot
-temp_slice.transpose('y', 'x').plot()
+# Plot directly - no transpose needed!
+temp_slice.plot()
 ```
 
 See [examples](https://github.com/google/Xee/tree/main/examples) or

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -113,14 +113,14 @@ class EEBackendArrayTest(absltest.TestCase):
 
   def test_creates_lat_long_array(self):
     arr = xee.EarthEngineBackendArray('longitude', self.lnglat_store)
-    self.assertEqual((1, 360, 180), arr.shape)
+    self.assertEqual((1, 180, 360), arr.shape)
 
   def test_can_create_object(self):
     arr = xee.EarthEngineBackendArray('B4', self.store)
 
     self.assertIsNotNone(arr)
 
-    self.assertEqual((64, 360, 180), arr.shape)
+    self.assertEqual((64, 180, 360), arr.shape)
     self.assertEqual(np.float32, arr.dtype)
     self.assertEqual('B4', arr.variable_name)
 
@@ -180,8 +180,8 @@ class EEBackendArrayTest(absltest.TestCase):
     self.assertEqual(
         [
             ((0, 0, 0), (0, 1, 500, 500, 1012, 1012)),
-            ((0, 0, 1), (0, 1, 500, 1012, 1012, 1025)),
-            ((0, 1, 0), (0, 1, 1012, 500, 1025, 1012)),
+            ((0, 0, 1), (0, 1, 1012, 500, 1025, 1012)),
+            ((0, 1, 0), (0, 1, 500, 1012, 1012, 1025)),
             ((0, 1, 1), (0, 1, 1012, 1012, 1025, 1025)),
         ],
         actual,
@@ -353,7 +353,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
     for v in ds.values():
       self.assertIsNotNone(v.data)
       self.assertFalse(v.isnull().all(), 'All values are null!')
-      self.assertEqual(v.shape, (n_images, width, height))
+      self.assertEqual(v.shape, (n_images, height, width))
 
 
   def test_open_dataset__n_images(self):
@@ -408,22 +408,28 @@ class EEBackendEntrypointTest(absltest.TestCase):
     np.testing.assert_allclose(
         ds['latitude'].values, 
         np.array([[
-          [37.764977, 37.764706, 37.764435, 37.764164],
-          [37.764973, 37.7647  , 37.76443 , 37.764164]
+          [37.764977, 37.764973],
+          [37.764706, 37.7647  ],
+          [37.764435, 37.76443 ],
+          [37.764164, 37.764164]
         ]])
     )
     np.testing.assert_allclose(
         ds['longitude'].values, 
         np.array([[
-          [-122.41528, -122.41529, -122.41529, -122.41529],
-          [-122.41495, -122.41495, -122.41495, -122.41495]
+          [-122.41528, -122.41495],
+          [-122.41529, -122.41495],
+          [-122.41529, -122.41495],
+          [-122.41529, -122.41495]
         ]])
     )
     np.testing.assert_allclose(
         ds['SR_B1'].values, 
         np.array([[
-          [14332., 13622., 12058., 11264.],
-          [12254., 10379., 10701., 11150.]
+          [14332., 12254.],
+          [13622., 10379.],
+          [12058., 10701.],
+          [11264., 11150.]
         ]])
     )
 

--- a/xee/ext_integration_test.py
+++ b/xee/ext_integration_test.py
@@ -333,7 +333,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         crs_transform=(12.0, 0, -180.0, 0, -25.0, 90.0),
         shape_2d=(width, height),
     )
-    self.assertEqual(dict(ds.sizes), {'time': 3, 'x': width, 'y': height})
+    self.assertEqual(dict(ds.sizes), {'time': 3, 'y': height, 'x': width})
     self.assertNotEmpty(dict(ds.coords))
     self.assertEqual(
       list(ds.data_vars.keys()),
@@ -404,7 +404,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
         shape_2d=(width, height),
     )
 
-    self.assertEqual(ds.sizes, {'time': 1, 'x': width, 'y': height})
+    self.assertEqual(ds.sizes, {'time': 1, 'y': height, 'x': width})
     np.testing.assert_allclose(
         ds['latitude'].values, 
         np.array([[
@@ -477,8 +477,8 @@ class EEBackendEntrypointTest(absltest.TestCase):
     }
     ds1 = self.entry.open_dataset('ee://LANDSAT/LC08/C02/T1', **test_params)
     ds2 = self.entry.open_dataset('ee:LANDSAT/LC08/C02/T1', **test_params)
-    self.assertEqual(dict(ds1.sizes), {'time': n_images, 'x': width, 'y': height})
-    self.assertEqual(dict(ds2.sizes), {'time': n_images, 'x': width, 'y': height})
+    self.assertEqual(dict(ds1.sizes), {'time': n_images, 'y': height, 'x': width})
+    self.assertEqual(dict(ds2.sizes), {'time': n_images, 'y': height, 'x': width})
     np.testing.assert_allclose(
       ds1['B1'].compute().values,
       ds2['B1'].compute().values
@@ -580,7 +580,7 @@ class EEBackendEntrypointTest(absltest.TestCase):
           **grid_dict
       )
 
-      ds = ds.isel(time=0).transpose('y', 'x')
+      ds = ds.isel(time=0)
       ds.rio.write_crs(crs, inplace=True)
       ds.rio.reproject(crs, inplace=True)
       ds.rio.to_raster(temp_file)


### PR DESCRIPTION
Xee currently uses `(time, x, y)` dimension ordering, which conflicts with NetCDF-CF conventions `(T, Z, Y, X)` and requires users to transpose data before plotting with matplotlib or xarray. This changes the dimension ordering to `(time, y, x)` to match standard conventions.

## Changes

**Core dimension ordering:**
- `dimension_names`: `('x', 'y')` → `('y', 'x')`
- Variable dimensions: `[time, x, y]` → `[time, y, x]`
- Array shape construction: `(n_images, width, height)` → `(n_images, height, width)`
- Data transpose from Earth Engine: `.T` → `.transpose(2, 0, 1)` to preserve (y, x) ordering

**Coordinate and chunking:**
- Coordinate list ordering updated to `[(time, ...), (y, height_coord), (x, width_coord)]`
- Dimension unpacking changed to `y_dim_name, x_dim_name = self.dimension_names` while maintaining correct x→width, y→height chunk mappings
- Indexing and tile iteration loops adjusted for new shape `(time, height, width)`

**Tests and documentation:**
- Integration tests updated to expect `{'time': n, 'y': height, 'x': width}`
- README example updated to remove transpose requirement

## Example

**Before:**
```python
ds = xr.open_dataset('ee://ECMWF/ERA5_LAND/MONTHLY_AGGR', engine='ee', **grid_params)
ds['temperature_2m'].isel(time=0).transpose('y', 'x').plot()  # transpose required
```

**After:**
```python
ds = xr.open_dataset('ee://ECMWF/ERA5_LAND/MONTHLY_AGGR', engine='ee', **grid_params)
ds['temperature_2m'].isel(time=0).plot()  # works directly
```

## Breaking Change

Existing code that explicitly depends on `(time, x, y)` ordering will need updates. This aligns Xee with matplotlib, xarray plotting, rasterio, and climate data conventions.