### PR TITLE
Fix syntax error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ with the high volume API:
 
 ```python
 ee.Initialize(
-    project='my-project-id'
+    project='my-project-id',
     opt_url='https://earthengine-highvolume.googleapis.com')
 ```
 


### PR DESCRIPTION
I forgot to add a comma when I wrote these docs! This creates an error when you copy+paste this code.