### PR TITLE
Consolidate Dependabot dependency updates

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,7 +40,7 @@ jobs:
       id-token: write  # This is required for requesting the JWT.
     steps:
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.13.0
+      uses: styfle/cancel-workflow-action@0.13.1
       with:
         access_token: ${{ github.token }}
       if: ${{github.ref != 'refs/head/main'}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         ]
     steps:
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.13.0
+      uses: styfle/cancel-workflow-action@0.13.1
       with:
         access_token: ${{ github.token }}
       if: ${{github.ref != 'refs/head/main'}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.13'
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: releases
           path: dist
@@ -64,7 +64,7 @@ jobs:
           ls -ltrh dist
       - name: Publish package to TestPyPI
         if: github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
           name: releases
           path: dist
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # doc requirements
 Jinja2==3.1.6
-myst-nb==1.3.0
+myst-nb==1.4.0
 myst-parser==4.0.1
 sphinx_rtd_theme==3.1.0
 sphinx==8.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tests = [
 dataflow = [
   "absl-py",
   "apache-beam[gcp]",
-  "gcsfs<=2026.1.0",
+  "gcsfs<=2026.3.0",
   "xarray-beam",
 ]
 examples = [


### PR DESCRIPTION
## Summary
Consolidate currently open Dependabot bumps into a single reviewable PR.

## Included updates
- `.github/workflows/publish.yml`
  - `actions/download-artifact@v6` -> `@v8`
  - `pypa/gh-action-pypi-publish@v1.13.0` -> `@v1.14.0`
- `.github/workflows/ci-build.yml`
  - `styfle/cancel-workflow-action@0.13.0` -> `@0.13.1`
- `.github/workflows/lint.yml`
  - `styfle/cancel-workflow-action@0.13.0` -> `@0.13.1`
- `pyproject.toml`
  - `gcsfs<=2026.1.0` -> `gcsfs<=2026.3.0`
- `docs/requirements.txt`
  - `myst-nb==1.3.0` -> `myst-nb==1.4.0`

## Why
This supersedes individual Dependabot PRs to reduce review overhead and merge queue churn.

## Supersedes
- #301
- #300
- #298
- #296
- #295