### PR TITLE
Update docs for stable 0.1.0 release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,10 @@
 # Xee Documentation (source files)
 
-> **⚠️ Breaking Change in v0.1.0**
+> **Breaking Change in v0.1.0+**
 >
-> v0.1.0 includes breaking API changes.
+> Xee v0.1.0 introduced a refactored API with breaking changes relative to the 0.0.x series. The documentation in this folder reflects the v0.1.0+ API.
 >
-> - Migration steps: [migration-guide-v0.1.0.md](migration-guide-v0.1.0.md)
-> - Install options (prerelease vs stable): [installation.md](installation.md)
+> If you are upgrading from 0.0.x, see [migration-guide-v0.1.0.md](migration-guide-v0.1.0.md).
 
 ## For nicely rendered documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,12 @@
 # Xee Documentation
 
-```{admonition} Breaking Change in v0.1.0
+```{admonition} Breaking change in v0.1.0+
 :class: warning
 
-A major refactor was released in v0.1.0, introducing breaking changes to the Xee API. In most cases, existing code written for pre-v0.1.0 versions will require updates to remain compatible.
+Xee v0.1.0 introduced a refactored API with breaking changes relative to the 0.0.x series. This documentation reflects the v0.1.0+ API.
 
-- See the [Migration Guide](migration-guide-v0.1.0.md) for details on updating your code.
-- If you need more time to migrate, you can pin your environment to the latest pre-v0.1.0 release.
-
-During the v0.1.0 prerelease window, `pip install xee` and `conda install xee` may still install the previous stable line. To follow this documentation for the refactored API, install with `pip install --upgrade --pre xee` (or a pinned RC such as `pip install xee==0.1.0rc1`).
+If you are upgrading from 0.0.x, see the [Migration Guide](migration-guide-v0.1.0.md).
 ```
-
 
 Xee is an Xarray extension for Google Earth Engine that lets you open `ee.Image` and `ee.ImageCollection` objects as lazy `xarray.Dataset`s.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,27 +2,9 @@
 
 Install Xee with pip or conda. Use virtual environments (`venv`, conda envs) to avoid dependency conflicts.
 
-```{admonition} Temporary note for v0.1.0 prerelease
-:class: warning
+Xee v0.1.0 introduced a refactored API with breaking changes relative to the 0.0.x series. This page documents the v0.1.0+ install and usage path. If you are upgrading from 0.0.x, review the [Migration Guide](migration-guide-v0.1.0.md).
 
-This documentation describes the refactored v0.1.0 API. During the prerelease period, default install commands may still resolve to the previous stable line.
-```
-
-## Install the v0.1.0 prerelease (refactored API)
-
-Use pip prerelease resolution:
-
-```shell
-pip install --upgrade --pre xee
-```
-
-Or pin a specific release candidate:
-
-```shell
-pip install xee==0.1.0rc1
-```
-
-## Install current stable (pre-v0.1.0 API)
+## Install
 
 Install from pip:
 
@@ -36,7 +18,23 @@ Install from conda-forge:
 conda install -c conda-forge xee
 ```
 
-Note: conda-forge may lag PyPI during prerelease testing. Use pip for the latest RCs.
+```{admonition} Prerelease versions
+:class: note
+
+Before each stable release, Xee publishes one or more release candidates (e.g. `v0.1.1rc1`) to PyPI. If you want to test upcoming changes before the stable release:
+
+```shell
+pip install --upgrade --pre xee
+```
+
+Or pin a specific release candidate:
+
+```shell
+pip install xee==0.1.1rc1
+```
+
+Prerelease builds are not published to Conda-Forge.
+```
 
 ## Earth Engine setup
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,17 +8,11 @@ Get up and running with Xee in a few minutes.
 
 ## 1. Install
 
-This quickstart uses the refactored v0.1.0 API. For canonical installation
-options (prerelease, stable, conda, and upgrade guidance), see
-[Installation](installation.md).
-
-Fast path (latest v0.1.0 prerelease from pip):
-
 ```bash
-pip install --upgrade --pre xee
+pip install --upgrade xee
 ```
 
-Optional (plotting): `pip install matplotlib`.
+Optional (plotting): `pip install matplotlib`. For full installation options, see [Installation](installation.md).
 
 ## 2. Earth Engine access
 


### PR DESCRIPTION
This updates the user-facing docs now that Xee 0.1.0 is the stable release.

Summary:
- remove prerelease-specific installation wording and `--pre` guidance from the main install/quickstart flow
- keep clear notice that v0.1.0+ is a breaking change relative to the 0.0.x series
- point users upgrading from 0.0.x to the migration guide
- keep a general note in installation docs explaining how prerelease testing works before future stable releases

Validation:
- `pixi run -e docs docs-check` passed