### PR TITLE
Fix nested fenced code blocks in admonitions

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -31,9 +31,8 @@ The tuple follows the [Rasterio/`affine.Affine`](https://affine.readthedocs.io/e
 
 Instead of constructing these manually, prefer helpers:
 
-- AOI means area of interest.
 - `extract_grid_params(obj)`: Match an `ee.Image` or `ee.ImageCollection` source grid.
-- `fit_geometry(geometry, grid_crs, grid_scale=(x, y))`: Define pixel size (resolution) over an AOI.
+- `fit_geometry(geometry, grid_crs, grid_scale=(x, y))`: Define pixel size (resolution) over an area of interest.
 - `fit_geometry(geometry, grid_crs, grid_shape=(w, h))`: Define output array dimensions, letting resolution float.
 
 ### Y Scale Sign & Orientation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,15 +23,11 @@ conda install -c conda-forge xee
 
 Before each stable release, Xee publishes one or more release candidates (e.g. `v0.1.1rc1`) to PyPI. If you want to test upcoming changes before the stable release:
 
-```shell
-pip install --upgrade --pre xee
-```
+`pip install --upgrade --pre xee`
 
 Or pin a specific release candidate:
 
-```shell
-pip install xee==0.1.1rc1
-```
+`pip install xee==0.1.1rc1`
 
 Prerelease builds are not published to Conda-Forge.
 ```


### PR DESCRIPTION
Fixes two MyST admonition blocks that contained nested fenced code blocks (` ``` ` inside ` ``` `), which caused incorrect rendering in the built HTML docs.

### Changes

- **`docs/installation.md`**: Replaced nested `shell` fenced blocks inside the "Prerelease versions" admonition with inline code lines.
- **`docs/concepts.md`**: Minor fix in the helpers list (removed a stray bullet and updated AOI wording to "area of interest").

Docs build (`docs-check`) passes with no errors or warnings.